### PR TITLE
Included revision as pod label and affinity label selectors for redis…

### DIFF
--- a/charts/redis-ha/templates/redis-haproxy-deployment.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-deployment.yaml
@@ -21,6 +21,7 @@ spec:
       labels:
         app: {{ template "redis-ha.name" . }}-haproxy
         release: {{ .Release.Name }}
+        revision: "{{ .Release.Revision }}"
       annotations:
       {{- if .Values.haproxy.metrics.enabled }}
         prometheus.io/port: "{{ .Values.haproxy.metrics.port }}"
@@ -56,6 +57,7 @@ spec:
                 matchLabels:
                   app: {{ template "redis-ha.name" . }}-haproxy
                   release: {{ .Release.Name }}
+                  revision: "{{ .Release.Revision }}"
               topologyKey: kubernetes.io/hostname
     {{- else }}
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -63,6 +65,7 @@ spec:
                 matchLabels:
                   app: {{ template "redis-ha.name" . }}-haproxy
                   release: {{ .Release.Name }}
+                  revision: "{{ .Release.Revision }}"
               topologyKey: kubernetes.io/hostname
     {{- end }}
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -72,6 +75,7 @@ spec:
                   matchLabels:
                     app:  {{ template "redis-ha.name" . }}-haproxy
                     release: {{ .Release.Name }}
+                    revision: "{{ .Release.Revision }}"
                 topologyKey: failure-domain.beta.kubernetes.io/zone
     {{- end }}
       initContainers:


### PR DESCRIPTION
#### What this PR does / why we need it:
It prevents redis ha proxy nodes to become unscheduled on a rolling upgrade operation, when the amount of nodes is the same as the amount of replicas.

#### Which issue this PR fixes
  - fixes #6

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
