### PR TITLE
Render .Values.haproxy.customConfig as template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+#### What this PR does / why we need it:
+
+#### Which issue this PR fixes
+*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
+  - fixes #
+
+#### Special notes for your reviewer:
+
+#### Checklist
+[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
+- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
+- [ ] Chart Version bumped
+- [ ] Variables are documented in the README.md
+- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.5.2
+version: 4.5.3
 appVersion: 5.0.6
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/_configs.tpl
+++ b/charts/redis-ha/templates/_configs.tpl
@@ -137,7 +137,7 @@
 
 {{- define "config-haproxy.cfg" }}
 {{- if .Values.haproxy.customConfig }}
-{{ .Values.haproxy.customConfig | indent 4}}
+{{ tpl .Values.haproxy.customConfig .  | indent 4}}
 {{- else }}
     defaults REDIS
       mode tcp


### PR DESCRIPTION
#### What this PR does / why we need it:

My team has a need to provide HA Proxy custom config but we need to use template values.

Use `tpl` to render `.Values.haproxy.customConfig` as a template the way `{{ tpl .Values.redis.customConfig . | indent 4 }}` and `{{ tpl .Values.sentinel.customConfig . | indent 4 }}` are handled. This appears to be an oversight/bug.