### PR TITLE
[dandydev/redis-ha] Fix Sentinel IDs that are too long since 4.5.4

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.5.4
+version: 4.5.5
 appVersion: 5.0.6
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -136,7 +136,7 @@ spec:
 {{- $replicas := int (toString .Values.replicas) -}}
 {{- range $i := until $replicas }}
         - name: SENTINEL_ID_{{ $i }}
-          value: {{ printf "%s\n%s\nindex: %d" (include "redis-ha.name" $) ($.Release.Name) $i | sha256sum }}
+          value: {{ printf "%s\n%s\nindex: %d" (include "redis-ha.name" $) ($.Release.Name) $i | sha256sum | trunc 40 }}
 {{ end -}}
 {{- if .Values.auth }}
         - name: AUTH


### PR DESCRIPTION
#### What this PR does / why we need it:

Sentinel IDs seems to have a size limit to be accepted. It needs to be taken into account in the chart.

#### Which issue this PR fixes
With 4.5.4, Sentinel IDs are generated from a SHA256 hashing (previously SHA1) that generates IDs of 64 characters (previously 40).

However Sentinel seems to not accept an ID of that lenght, and typically error with the following message in the Sentinel pod:
```
2020-04-20T09:50:08.670891663Z *** FATAL CONFIG FILE ERROR ***
2020-04-20T09:50:08.670903865Z Reading the configuration file, at line 1
2020-04-20T09:50:08.670910764Z >>> 'sentinel myid ce2c4ca90e2a38b75ca5a2b56ce1587f99af187d459d04d9ef39494c173fcd13'
2020-04-20T09:50:08.670919532Z Malformed Sentinel id in myid option.
```
This PR fixes that by trimming to 40 characters the SHA256 hash. I did not get back to SHA1 because arguments given about inconsistent support of SHA1 in Helm are quite valid (see #15).

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
