### PR TITLE
[chart/redis-ha] Increase timeoutSeconds for exporter

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.5.7
+version: 4.5.8
 appVersion: 5.0.6
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -249,7 +249,7 @@ spec:
             path: {{ .Values.exporter.scrapePath }}
             port: {{ .Values.exporter.port }}
           initialDelaySeconds: 15
-          timeoutSeconds: 1
+          timeoutSeconds: 5
           periodSeconds: 15
         resources:
 {{ toYaml .Values.exporter.resources | indent 10 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

We were encountering multiple warnings like

> 110m        Warning   Unhealthy                      pod/hm-production-redis-server-1                             Liveness probe failed: Get http://10.244.36.168:9121/metrics: net/http: request canceled (Client.Timeout exceeded while awaiting headers)

Specifically targeting metrics endpoint. Increasing time timeoutSeconds resolved it.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
