### PR TITLE
[charts/redis-ha] Fix PDB selector to not match test pods

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.6.1
+version: 4.6.2
 appVersion: 5.0.6
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-pdb.yaml
+++ b/charts/redis-ha/templates/redis-ha-pdb.yaml
@@ -9,6 +9,9 @@ metadata:
 spec:
   selector:
     matchLabels:
+      # The replica label is set on StatefulSet pods but not the Test pods
+      # We want to avoid including the Test pods in the budget
+      {{ template "redis-ha.fullname" . }}: replica
       release: {{ .Release.Name }}
       app: {{ template "redis-ha.name" . }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}


### PR DESCRIPTION
Signed-off-by: Leo Petrazickis <leons@autonomic.ai>

#### What this PR does / why we need it:
There's a bug in the PodDisruptionBudget selector that includes pods that shouldn't be in scope.

#### Which issue this PR fixes
  - fixes #45 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
