### PR TITLE
[charts/redis-ha] Removing timeout from liveness shell process.

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.10.3
+version: 4.10.4
 appVersion: 6.0.7
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/_configs.tpl
+++ b/charts/redis-ha/templates/_configs.tpl
@@ -485,9 +485,10 @@
 {{- end }}
 
 {{- define "redis_liveness.sh" }}
+    {{- if not (ne (int .Values.sentinel.port) 0) }}
     TLS_CLIENT_OPTION="--tls --cacert /tls-certs/{{ .Values.tls.caCertFile }} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}"
+    {{- end }}
     response=$(
-      timeout -s 3 $1 \
       redis-cli \
       {{- if .Values.auth }}
         -a "${AUTH}" --no-auth-warning \
@@ -508,9 +509,10 @@
 {{- end }}
 
 {{- define "sentinel_liveness.sh" }}
+    {{- if not (ne (int .Values.sentinel.port) 0) }}
     TLS_CLIENT_OPTION="--tls --cacert /tls-certs/{{ .Values.tls.caCertFile }} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}"
+    {{- end }}
     response=$(
-      timeout -s 3 $1 \
       redis-cli \
       {{- if .Values.auth }}
         -a "${SENTINELAUTH}" --no-auth-warning \

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -261,7 +261,7 @@ spec:
             command:
               - sh
               - -c
-              - /health/redis_liveness.sh {{ .Values.redis.livenessProbe.timeoutSeconds }}
+              - /health/redis_liveness.sh
         resources:
 {{ toYaml .Values.redis.resources | indent 10 }}
         ports:
@@ -324,7 +324,7 @@ spec:
             command:
               - sh
               - -c
-              - /health/sentinel_liveness.sh {{ .Values.sentinel.livenessProbe.timeoutSeconds }}
+              - /health/sentinel_liveness.sh
         resources:
 {{ toYaml .Values.sentinel.resources | indent 10 }}
         ports:


### PR DESCRIPTION
#### What this PR does / why we need it:
Looks like using `timeout` in a process within the Redis containers isn't killing or doing anything with it. I also don't see a need for the timeout because the liveness already has this in place. 

Removing entirely. As well as adding small logic to remove TLS params when TLS disabled. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #76

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/mychartname]`)
