### PR TITLE
Newer versions of haproxy expect LF on config last line

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.10.11
+version: 4.10.12
 appVersion: 6.0.7
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-configmap.yaml
+++ b/charts/redis-ha/templates/redis-ha-configmap.yaml
@@ -21,7 +21,7 @@ data:
   init.sh: |
 {{- include "config-init.sh" . }}
 {{ if .Values.haproxy.enabled }}
-  haproxy.cfg: |-
+  haproxy.cfg: |
 {{- include "config-haproxy.cfg" . }}
 {{- end }}
   haproxy_init.sh: |


### PR DESCRIPTION
The current chart fails with haproxy 2.3.2 with following error:

```[NOTICE] 001/071757 (1) : haproxy version is 2.3.2-d522db7
[NOTICE] 001/071757 (1) : path to executable is /usr/local/sbin/haproxy
[ALERT] 001/071757 (1) : parsing [/usr/local/etc/haproxy/haproxy.cfg:82]: Missing LF on last line, file might have been truncated at position 68.
[ALERT] 001/071757 (1) : Error(s) found in configuration file : /usr/local/etc/haproxy/haproxy.cfg
[ALERT] 001/071757 (1) : Fatal errors found in configuration.
```

This patch fixes the issue