### PR TITLE
Add separate redis_readiness check

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.12.5
+version: 4.12.6
 appVersion: 6.0.7
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-health-configmap.yaml
+++ b/charts/redis-ha/templates/redis-ha-health-configmap.yaml
@@ -11,5 +11,7 @@ metadata:
 data:
   redis_liveness.sh: |
 {{- include "redis_liveness.sh" . }}
+  redis_readiness.sh: |
+{{- include "redis_readiness.sh" . }}
   sentinel_liveness.sh: |
 {{- include "sentinel_liveness.sh" . }}

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/init-config: {{ print (include "config-redis.conf" .) (include "config-init.sh" .) (include "redis_liveness.sh" .) (include "sentinel_liveness.sh" .) | sha256sum }}
+        checksum/init-config: {{ print (include "config-redis.conf" .) (include "config-init.sh" .) (include "redis_liveness.sh" .) (include "redis_readiness.sh" .) (include "sentinel_liveness.sh" .) | sha256sum }}
       {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
@@ -274,7 +274,7 @@ spec:
             command:
               - sh
               - -c
-              - /health/redis_liveness.sh
+              - /health/redis_readiness.sh
         resources:
 {{ toYaml .Values.redis.resources | indent 10 }}
         ports:


### PR DESCRIPTION
With recent changes to redis_liveness.sh, the POD (wrongly) will be marked as ready when a sync is in progress.
I've added an new redis_readiness.sh.