### PR TITLE
Add option to change terminationGracePeriodSeconds

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.12.2
+version: 4.12.3
 appVersion: 6.0.7
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -41,6 +41,9 @@ spec:
         {{ $key }}: {{ $value | toString }}
         {{- end }}
     spec:
+      {{- if .Values.redis.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.redis.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
       {{- end }}

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -194,6 +194,10 @@ redis:
   ## It is possible to disable client side certificates authentication when "authClients" is set to "no"
   # authClients: "no"
 
+  ## Increase terminationGracePeriodSeconds to allow writing large RDB snapshots. (k8s default is 30s)
+  ## https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination-forced
+  terminationGracePeriodSeconds: 60
+
   # liveness probe parameters for redis container
   livenessProbe:
     initialDelaySeconds: 30


### PR DESCRIPTION
For large redis instances (50GB for instance) and slow disks, writing RDB snapshot to disks may require more time (even 5 minutes), and terminationGracePeriodSeconds should be configurable.