### PR TITLE
Handle Sentinel auth, use env vars in HAProxy config

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.12.16
+version: 4.12.17
 appVersion: 6.0.7
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/_configs.tpl
+++ b/charts/redis-ha/templates/_configs.tpl
@@ -375,8 +375,8 @@
       mode tcp
       option tcp-check
       tcp-check connect
-      {{- if $root.auth }}
-      tcp-check send AUTH\ {{ $root.redisPassword }}\r\n
+      {{- if $root.Values.sentinel.auth }}
+      tcp-check send "AUTH ${SENTINELAUTH}"\r\n
       tcp-check expect string +OK
       {{- end }}
       tcp-check send PING\r\n
@@ -411,7 +411,7 @@
       option tcp-check
       tcp-check connect
       {{- if .Values.auth }}
-      tcp-check send AUTH\ REPLACE_AUTH_SECRET\r\n
+      tcp-check send "AUTH ${AUTH}"\r\n
       tcp-check expect string +OK
       {{- end }}
       tcp-check send PING\r\n
@@ -479,11 +479,6 @@
     fi
     sed -i "s/REPLACE_ANNOUNCE{{ $i }}/$ANNOUNCE_IP{{ $i }}/" "$HAPROXY_CONF"
 
-    if [ "${AUTH:-}" ]; then
-        echo "Setting auth values"
-        ESCAPED_AUTH=$(echo "$AUTH" | sed -e 's/[\/&]/\\&/g');
-        sed -i "s/REPLACE_AUTH_SECRET/${ESCAPED_AUTH}/" "$HAPROXY_CONF"
-    fi
     {{- end }}
 {{- end }}
 

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -139,7 +139,7 @@ spec:
 {{- range $i := until $replicas }}
         - name: SENTINEL_ID_{{ $i }}
           value: {{ printf "%s\n%s\nindex: %d" (include "redis-ha.name" $) ($.Release.Name) $i | sha256sum | trunc 40 }}
-{{ end -}}
+{{- end }}
 {{- if .Values.auth }}
         - name: AUTH
           valueFrom:
@@ -304,8 +304,9 @@ spec:
           - redis-sentinel
         args:
           - /data/conf/sentinel.conf
-{{- if .Values.auth }}
+{{- if or .Values.auth .Values.sentinel.auth}}
         env:
+  {{- if .Values.auth }}
         - name: AUTH
           valueFrom:
             secretKeyRef:
@@ -315,8 +316,8 @@ spec:
               name: {{ template "redis-ha.fullname" . }}
             {{- end }}
               key: {{ .Values.authKey }}
-{{- end }}
-{{- if .Values.sentinel.auth }}
+  {{- end }}
+  {{- if .Values.sentinel.auth }}
         - name: SENTINELAUTH
           valueFrom:
             secretKeyRef:
@@ -326,6 +327,7 @@ spec:
               name: {{ template "redis-ha.fullname" . }}-sentinel
             {{- end }}
               key: {{ .Values.sentinel.authKey }}
+  {{- end }}
 {{- end }}
         livenessProbe:
           initialDelaySeconds: {{ .Values.sentinel.livenessProbe.initialDelaySeconds }}

--- a/charts/redis-ha/templates/redis-haproxy-deployment.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-deployment.yaml
@@ -84,18 +84,6 @@ spec:
         - sh
         args:
         - /readonly/haproxy_init.sh
-{{- if .Values.auth }}
-        env:
-        - name: AUTH
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.existingSecret }}
-              name: {{ .Values.existingSecret }}
-            {{- else }}
-              name: {{ template "redis-ha.fullname" . }}
-            {{- end }}
-              key: {{ .Values.authKey }}
-{{- end }}
         volumeMounts:
         - name: config-volume
           mountPath: /readonly
@@ -111,6 +99,31 @@ spec:
       - name: haproxy
         image: {{ .Values.haproxy.image.repository }}:{{ .Values.haproxy.image.tag }}
         imagePullPolicy: {{ .Values.haproxy.image.pullPolicy }}
+    {{- if or .Values.auth .Values.sentinel.auth}}
+        env:
+      {{- if .Values.auth }}
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+            {{- if .Values.existingSecret }}
+              name: {{ .Values.existingSecret }}
+            {{- else }}
+              name: {{ template "redis-ha.fullname" . }}
+            {{- end }}
+              key: {{ .Values.authKey }}
+      {{- end }}
+      {{- if .Values.sentinel.auth }}
+        - name: SENTINELAUTH
+          valueFrom:
+            secretKeyRef:
+            {{- if .Values.sentinel.existingSecret }}
+              name: {{ .Values.sentinel.existingSecret }}
+            {{- else }}
+              name: {{ template "redis-ha.fullname" . }}-sentinel
+            {{- end }}
+              key: {{ .Values.sentinel.authKey }}
+      {{- end }}
+    {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
#### What this PR does / why we need it:

- Adds handling of Sentinel auth in HAProxy, 
- Handles ONLY Sentinel auth being set
- Uses env vars in HAProxy config to avoid/fix escaping issues in Redis and Sentinel passwords

#### Which issue this PR fixes
  - fixes #133

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
