### PR TITLE
[charts/redis-ha] Add additional labels

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.12.21
+version: 4.12.22
 appVersion: 6.0.7
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/README.md
+++ b/charts/redis-ha/README.md
@@ -218,6 +218,7 @@ The following table lists the configurable parameters of the Redis chart and the
 | `extraContainers`         | Extra containers to include in StatefulSet                                                                                                                                                               |`[]`|
 | `extraInitContainers`     | Extra init containers to include in StatefulSet                                                                                                                                                          |`[]`|
 | `extraVolumes`            | Extra volumes to include in StatefulSet                                                                                                                                                                  |`[]`|
+| `additionalLabels`        | Labels that should be applied to all created resources                                                                                                                                                   |`{}`|
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/redis-ha/README.md
+++ b/charts/redis-ha/README.md
@@ -218,7 +218,7 @@ The following table lists the configurable parameters of the Redis chart and the
 | `extraContainers`         | Extra containers to include in StatefulSet                                                                                                                                                               |`[]`|
 | `extraInitContainers`     | Extra init containers to include in StatefulSet                                                                                                                                                          |`[]`|
 | `extraVolumes`            | Extra volumes to include in StatefulSet                                                                                                                                                                  |`[]`|
-| `additionalLabels`        | Labels that should be applied to all created resources                                                                                                                                                   |`{}`|
+| `extraLabels`             | Labels that should be applied to all created resources                                                                                                                                                        |`{}`|
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/redis-ha/templates/redis-auth-secret.yaml
+++ b/charts/redis-ha/templates/redis-auth-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 type: Opaque

--- a/charts/redis-ha/templates/redis-auth-secret.yaml
+++ b/charts/redis-ha/templates/redis-auth-secret.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 type: Opaque
 data:
   {{ .Values.authKey }}: {{ .Values.redisPassword | b64enc | quote }}

--- a/charts/redis-ha/templates/redis-ha-announce-service.yaml
+++ b/charts/redis-ha/templates/redis-ha-announce-service.yaml
@@ -11,6 +11,9 @@ metadata:
   namespace: {{ $namespace | quote}}
   labels:
 {{ include "labels.standard" $root | indent 4 }}
+    {{- range $key, $value := $root.Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   {{- if $root.Values.serviceAnnotations }}

--- a/charts/redis-ha/templates/redis-ha-announce-service.yaml
+++ b/charts/redis-ha/templates/redis-ha-announce-service.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ $namespace | quote}}
   labels:
 {{ include "labels.standard" $root | indent 4 }}
-    {{- range $key, $value := $root.Values.additionalLabels }}
+    {{- range $key, $value := $root.Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   annotations:

--- a/charts/redis-ha/templates/redis-ha-configmap.yaml
+++ b/charts/redis-ha/templates/redis-ha-configmap.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- range $key, $value := .Values.configmap.labels }}
     {{ $key }}: {{ $value | toString }}
     {{- end }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 data:
   redis.conf: |
 {{- include "config-redis.conf" . }}

--- a/charts/redis-ha/templates/redis-ha-configmap.yaml
+++ b/charts/redis-ha/templates/redis-ha-configmap.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- range $key, $value := .Values.configmap.labels }}
     {{ $key }}: {{ $value | toString }}
     {{- end }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 data:

--- a/charts/redis-ha/templates/redis-ha-exporter-script-configmap.yaml
+++ b/charts/redis-ha/templates/redis-ha-exporter-script-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 data:

--- a/charts/redis-ha/templates/redis-ha-exporter-script-configmap.yaml
+++ b/charts/redis-ha/templates/redis-ha-exporter-script-configmap.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 data:
   script: {{ toYaml .Values.exporter.script | indent 2 }}
 {{- end }}

--- a/charts/redis-ha/templates/redis-ha-health-configmap.yaml
+++ b/charts/redis-ha/templates/redis-ha-health-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "redis-ha.fullname" . }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 data:

--- a/charts/redis-ha/templates/redis-ha-health-configmap.yaml
+++ b/charts/redis-ha/templates/redis-ha-health-configmap.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "redis-ha.fullname" . }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 data:
   redis_liveness.sh: |
 {{- include "redis_liveness.sh" . }}

--- a/charts/redis-ha/templates/redis-ha-pdb.yaml
+++ b/charts/redis-ha/templates/redis-ha-pdb.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/redis-ha/templates/redis-ha-pdb.yaml
+++ b/charts/redis-ha/templates/redis-ha-pdb.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:

--- a/charts/redis-ha/templates/redis-ha-psp.yaml
+++ b/charts/redis-ha/templates/redis-ha-psp.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "redis-ha.fullname" . }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:

--- a/charts/redis-ha/templates/redis-ha-psp.yaml
+++ b/charts/redis-ha/templates/redis-ha-psp.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ template "redis-ha.fullname" . }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   allowPrivilegeEscalation: false
 {{- if .Values.securityContext.sysctls }}

--- a/charts/redis-ha/templates/redis-ha-role.yaml
+++ b/charts/redis-ha/templates/redis-ha-role.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 rules:
 - apiGroups:
     - ""

--- a/charts/redis-ha/templates/redis-ha-role.yaml
+++ b/charts/redis-ha/templates/redis-ha-role.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 rules:

--- a/charts/redis-ha/templates/redis-ha-rolebinding.yaml
+++ b/charts/redis-ha/templates/redis-ha-rolebinding.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "redis-ha.serviceAccountName" . }}

--- a/charts/redis-ha/templates/redis-ha-rolebinding.yaml
+++ b/charts/redis-ha/templates/redis-ha-rolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 subjects:

--- a/charts/redis-ha/templates/redis-ha-secret.yaml
+++ b/charts/redis-ha/templates/redis-ha-secret.yaml
@@ -15,6 +15,9 @@ metadata:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "redis-ha.fullname" . }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 type: Opaque
 data:
 {{- if regexFind $regexRestoreSSH (toString .Values.restore.ssh.source) }}

--- a/charts/redis-ha/templates/redis-ha-secret.yaml
+++ b/charts/redis-ha/templates/redis-ha-secret.yaml
@@ -15,7 +15,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "redis-ha.fullname" . }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 type: Opaque

--- a/charts/redis-ha/templates/redis-ha-service.yaml
+++ b/charts/redis-ha/templates/redis-ha-service.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- if .Values.exporter.enabled }}
     exporter: enabled
 {{- end }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
   annotations:
   {{- if .Values.serviceAnnotations }}
 {{ toYaml .Values.serviceAnnotations | indent 4 }}

--- a/charts/redis-ha/templates/redis-ha-service.yaml
+++ b/charts/redis-ha/templates/redis-ha-service.yaml
@@ -8,7 +8,7 @@ metadata:
 {{- if .Values.exporter.enabled }}
     exporter: enabled
 {{- end }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   annotations:

--- a/charts/redis-ha/templates/redis-ha-serviceaccount.yaml
+++ b/charts/redis-ha/templates/redis-ha-serviceaccount.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "redis-ha.fullname" . }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 {{- if or .Values.auth .Values.sentinel.auth }}

--- a/charts/redis-ha/templates/redis-ha-serviceaccount.yaml
+++ b/charts/redis-ha/templates/redis-ha-serviceaccount.yaml
@@ -9,6 +9,9 @@ metadata:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "redis-ha.fullname" . }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 {{- if or .Values.auth .Values.sentinel.auth }}
 secrets:
 {{- end }}

--- a/charts/redis-ha/templates/redis-ha-servicemonitor.yaml
+++ b/charts/redis-ha/templates/redis-ha-servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
 {{- if .Values.exporter.serviceMonitor.namespace }}
   namespace: {{ .Values.exporter.serviceMonitor.namespace | quote }}
 {{- end }}
-  {{- range $key, $value := .Values.additionalLabels }}
+  {{- range $key, $value := .Values.extraLabels }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:

--- a/charts/redis-ha/templates/redis-ha-servicemonitor.yaml
+++ b/charts/redis-ha/templates/redis-ha-servicemonitor.yaml
@@ -11,6 +11,9 @@ metadata:
 {{- if .Values.exporter.serviceMonitor.namespace }}
   namespace: {{ .Values.exporter.serviceMonitor.namespace | quote }}
 {{- end }}
+  {{- range $key, $value := .Values.additionalLabels }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   endpoints:
   - targetPort: {{ .Values.exporter.port }}

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{ template "redis-ha.fullname" . }}: replica
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 {{ include "labels.standard" . | indent 4 }}
@@ -43,7 +43,7 @@ spec:
         {{- range $key, $value := .Values.labels }}
         {{ $key }}: {{ $value | toString }}
         {{- end }}
-        {{- range $key, $value := .Values.additionalLabels }}
+        {{- range $key, $value := .Values.extraLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -8,6 +8,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{ template "redis-ha.fullname" . }}: replica
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 {{ include "labels.standard" . | indent 4 }}
   annotations:
 {{ toYaml .Values.redis.annotations | indent 4 }}
@@ -39,6 +42,9 @@ spec:
         {{ template "redis-ha.fullname" . }}: replica
         {{- range $key, $value := .Values.labels }}
         {{ $key }}: {{ $value | toString }}
+        {{- end }}
+        {{- range $key, $value := .Values.additionalLabels }}
+        {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
       {{- if .Values.redis.terminationGracePeriodSeconds }}

--- a/charts/redis-ha/templates/redis-haproxy-deployment.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
@@ -28,7 +28,7 @@ spec:
         {{- range $key, $value := .Values.haproxy.labels }}
         {{ $key }}: {{ $value | toString }}
         {{- end }}
-        {{- range $key, $value := .Values.additionalLabels }}
+        {{- range $key, $value := .Values.extraLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       annotations:

--- a/charts/redis-ha/templates/redis-haproxy-deployment.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   strategy:
     type: RollingUpdate
@@ -24,6 +27,9 @@ spec:
         revision: "{{ .Release.Revision }}"
         {{- range $key, $value := .Values.haproxy.labels }}
         {{ $key }}: {{ $value | toString }}
+        {{- end }}
+        {{- range $key, $value := .Values.additionalLabels }}
+        {{ $key }}: {{ $value | quote }}
         {{- end }}
       annotations:
       {{- if and (.Values.haproxy.metrics.enabled) (not .Values.haproxy.metrics.serviceMonitor.enabled)  }}

--- a/charts/redis-ha/templates/redis-haproxy-pdb.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-pdb.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/redis-ha/templates/redis-haproxy-pdb.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-pdb.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:

--- a/charts/redis-ha/templates/redis-haproxy-psp.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-psp.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
 {{ include "labels.standard" . | indent 4 }}
     component: {{ template "redis-ha.fullname" . }}-haproxy
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:

--- a/charts/redis-ha/templates/redis-haproxy-psp.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-psp.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
 {{ include "labels.standard" . | indent 4 }}
     component: {{ template "redis-ha.fullname" . }}-haproxy
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   allowPrivilegeEscalation: false
   fsGroup:

--- a/charts/redis-ha/templates/redis-haproxy-role.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-role.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
 {{ include "labels.standard" . | indent 4 }}
     component: {{ template "redis-ha.fullname" . }}-haproxy
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 rules:

--- a/charts/redis-ha/templates/redis-haproxy-role.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-role.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
 {{ include "labels.standard" . | indent 4 }}
     component: {{ template "redis-ha.fullname" . }}-haproxy
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 rules:
 - apiGroups:
     - ""

--- a/charts/redis-ha/templates/redis-haproxy-rolebinding.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-rolebinding.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
 {{ include "labels.standard" . | indent 4 }}
     component: {{ template "redis-ha.fullname" . }}-haproxy
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "redis-ha.serviceAccountName" . }}-haproxy

--- a/charts/redis-ha/templates/redis-haproxy-rolebinding.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-rolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
 {{ include "labels.standard" . | indent 4 }}
     component: {{ template "redis-ha.fullname" . }}-haproxy
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 subjects:

--- a/charts/redis-ha/templates/redis-haproxy-service.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
 {{ include "labels.standard" . | indent 4 }}
     component: {{ template "redis-ha.fullname" . }}-haproxy
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   annotations:

--- a/charts/redis-ha/templates/redis-haproxy-service.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-service.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
 {{ include "labels.standard" . | indent 4 }}
     component: {{ template "redis-ha.fullname" . }}-haproxy
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
   annotations:
   {{- if .Values.haproxy.service.annotations }}
 {{ toYaml .Values.haproxy.service.annotations | indent 4 }}

--- a/charts/redis-ha/templates/redis-haproxy-serviceaccount.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-serviceaccount.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "redis-ha.fullname" . }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 {{- end }}

--- a/charts/redis-ha/templates/redis-haproxy-serviceaccount.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-serviceaccount.yaml
@@ -9,4 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "redis-ha.fullname" . }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 {{- end }}

--- a/charts/redis-ha/templates/redis-haproxy-servicemonitor.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
 {{- if .Values.haproxy.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.haproxy.metrics.serviceMonitor.namespace | quote }}
 {{- end }}
-  {{- range $key, $value := .Values.additionalLabels }}
+  {{- range $key, $value := .Values.extraLabels }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:

--- a/charts/redis-ha/templates/redis-haproxy-servicemonitor.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-servicemonitor.yaml
@@ -10,6 +10,9 @@ metadata:
 {{- if .Values.haproxy.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.haproxy.metrics.serviceMonitor.namespace | quote }}
 {{- end }}
+  {{- range $key, $value := .Values.additionalLabels }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   endpoints:
   - targetPort: {{ .Values.haproxy.metrics.port }}

--- a/charts/redis-ha/templates/redis-tls-secret.yaml
+++ b/charts/redis-ha/templates/redis-tls-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 type: Opaque

--- a/charts/redis-ha/templates/redis-tls-secret.yaml
+++ b/charts/redis-ha/templates/redis-tls-secret.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 type: Opaque
 data:
   {{- if .Values.tls.caCertFile }}

--- a/charts/redis-ha/templates/sentinel-auth-secret.yaml
+++ b/charts/redis-ha/templates/sentinel-auth-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
-    {{- range $key, $value := .Values.additionalLabels }}
+    {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 type: Opaque

--- a/charts/redis-ha/templates/sentinel-auth-secret.yaml
+++ b/charts/redis-ha/templates/sentinel-auth-secret.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 type: Opaque
 data:
   {{ .Values.sentinel.authKey }}: {{ .Values.sentinel.password | b64enc | quote }}

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -593,4 +593,4 @@ extraVolumes: []
 #    emptyDir: {}
 
 # Labels added here are applied to all created resources
-additionalLabels: []
+additionalLabels: {}

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -593,4 +593,4 @@ extraVolumes: []
 #    emptyDir: {}
 
 # Labels added here are applied to all created resources
-additionalLabels: {}
+extraLabels: {}

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -591,3 +591,6 @@ extraContainers: []
 extraVolumes: []
 #  - name: empty
 #    emptyDir: {}
+
+# Labels added here are applied to all created resources
+additionalLabels: []


### PR DESCRIPTION
#### What this PR does / why we need it:

Consumers may have a requirement to have governance labels applied to all (or a subset of) resources. Currently the consumer has the option to specify some labels, but instead of playing whack-a-mole it may be easier to have a key for labels that will be applied to all resources.

#### Which issue this PR fixes
  - fixes #142 

#### Special notes for your reviewer:
Let me know if a different key to `additionalLabels` is required. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
