### PR TITLE
[stable/redis-ha] Update network policy to allow HAProxy connectivity when enabled

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.14.3
+version: 4.14.4
 appVersion: 6.2.5
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-network-policy.yaml
+++ b/charts/redis-ha/templates/redis-ha-network-policy.yaml
@@ -58,6 +58,18 @@ spec:
           protocol: TCP
         - port: {{ .Values.sentinel.port }}
           protocol: TCP
+{{- if .Values.haproxy.enabled }}
+    - from:
+        - podSelector:
+            matchLabels:
+              release: {{ .Release.Name }}
+              app: {{ template "redis-ha.name" . }}-haproxy
+      ports:
+        - port: {{ .Values.redis.port }}
+          protocol: TCP
+        - port: {{ .Values.sentinel.port }}
+          protocol: TCP
+{{- end }}
 {{-  range $rule := .Values.networkPolicy.ingressRules }}
     - from:
 {{ (tpl (toYaml $rule.selectors) $) | indent 7 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows connectivity from HAProxy pods to redis pods on 26379 6379 tcp when HAProxy is enabled
#### Which issue this PR fixes
#155 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [/ ] Chart Version bumped
- [/ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
