### PR TITLE
[stable/redis-ha] Fix service-monitor labels

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.14.7
+version: 4.14.8
 appVersion: 6.2.5
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-servicemonitor.yaml
+++ b/charts/redis-ha/templates/redis-ha-servicemonitor.yaml
@@ -2,18 +2,16 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-{{- if .Values.exporter.serviceMonitor.labels }}
-  labels:
-{{ toYaml .Values.exporter.serviceMonitor.labels | indent 4}}
-{{- end }}
   name: {{ template "redis-ha.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
-{{- if .Values.exporter.serviceMonitor.namespace }}
-  namespace: {{ .Values.exporter.serviceMonitor.namespace | quote }}
-{{- end }}
-  {{- range $key, $value := .Values.extraLabels }}
-  {{ $key }}: {{ $value | quote }}
-  {{- end }}
+  namespace: {{ .Values.exporter.serviceMonitor.namespace | default .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- range $key, $value := .Values.exporter.serviceMonitor.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   endpoints:
   - targetPort: {{ .Values.exporter.port }}

--- a/charts/redis-ha/templates/redis-haproxy-servicemonitor.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-servicemonitor.yaml
@@ -2,17 +2,16 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-{{- with .Values.haproxy.metrics.serviceMonitor.labels }}
-  labels: {{ toYaml . | nindent 4}}
-{{- end }}
   name: {{ template "redis-ha.fullname" . }}-haproxy
-  namespace: {{ .Release.Namespace | quote }}
-{{- if .Values.haproxy.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.haproxy.metrics.serviceMonitor.namespace | quote }}
-{{- end }}
-  {{- range $key, $value := .Values.extraLabels }}
-  {{ $key }}: {{ $value | quote }}
-  {{- end }}
+  namespace: {{ .Values.haproxy.metrics.serviceMonitor.namespace | default .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- range $key, $value := .Values.haproxy.metrics.serviceMonitor.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   endpoints:
   - targetPort: {{ .Values.haproxy.metrics.port }}


### PR DESCRIPTION
#### What this PR does / why we need it:

The labels for service monitors (redis+haproxy) are not working as expected. There are global missing labels and helm fails when service monitor labels are provided along with extraLabels.

#### Which issue this PR fixes

Helm template output for current version shows the extra label key outside of labels and duplicated namespace, this fails the deploy:

```sh
 → helm template . \
    --set=replicas=1 \
    --set=exporter.enabled=true \
    --set=exporter.serviceMonitor.enabled=true \
    --set=extraLabels.extralabel-key=extralabel-value \
    --set=exporter.serviceMonitor.labels.svcmon-key=svcmon-value \
    --set=exporter.serviceMonitor.namespace=monitor-namespace \
    --api-versions=monitoring.coreos.com/v1

[...]
---
# Source: redis-ha/templates/redis-ha-servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  labels:
    svcmon-key: svcmon-value
  name: RELEASE-NAME-redis-ha
  namespace: "default"
  namespace: "monitor-namespace"
  extralabel-key: "extralabel-value"
spec:
  endpoints:
  - targetPort: 9121
  jobLabel: RELEASE-NAME-redis-ha
  namespaceSelector:
    matchNames:
    - "default"
  selector:
    matchLabels:
      app: redis-ha
      release: RELEASE-NAME
      exporter: enabled
[...]
```

With this PR the result will include the missing global labels and also optional labels with correct indentation:

```sh

 → helm template . \
    --set=replicas=1 \
    --set=exporter.enabled=true \
    --set=exporter.serviceMonitor.enabled=true \
    --set=extraLabels.extralabel-key=extralabel-value \
    --set=exporter.serviceMonitor.labels.svcmon-key=svcmon-value \
    --set=exporter.serviceMonitor.namespace=monitor-namespace \
    --api-versions=monitoring.coreos.com/v1

[...]
---
# Source: redis-ha/templates/redis-ha-servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: RELEASE-NAME-redis-ha
  namespace: "monitor-namespace"
  labels:
    app: redis-ha
    heritage: "Helm"
    release: "RELEASE-NAME"
    chart: redis-ha-4.14.8
    extralabel-key: "extralabel-value"
    svcmon-key: "svcmon-value"
spec:
  endpoints:
  - targetPort: 9121
  jobLabel: RELEASE-NAME-redis-ha
  namespaceSelector:
    matchNames:
    - "default"
  selector:
    matchLabels:
      app: redis-ha
      release: RELEASE-NAME
      exporter: enabled
[...]
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
