### PR TITLE
redis-ha: fix haproxy auth config

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.14.9
+version: 4.14.10
 appVersion: 6.2.5
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/_configs.tpl
+++ b/charts/redis-ha/templates/_configs.tpl
@@ -518,7 +518,7 @@
       option tcp-check
       tcp-check connect
       {{- if .Values.auth }}
-      tcp-check send AUTH\ REPLACE_AUTH_SECRET\r\n
+      tcp-check send "AUTH ${AUTH}"\r\n
       tcp-check expect string +OK
       {{- end }}
       tcp-check send PING\r\n


### PR DESCRIPTION
#### What this PR does / why we need it

This PR fixes missing ENV var replacement in HAProxy config for slave backend in `redis-ha` chart.

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
