### PR TITLE
[redis-ha] Update README.md

### DIFF
--- a/charts/redis-ha/README.md
+++ b/charts/redis-ha/README.md
@@ -239,6 +239,7 @@ The following table lists the configurable parameters of the Redis chart and the
 | `networkPolicy.egressRules[].selectors`   | Label selector query to define resources for this egress rule                                                                                                                            |`[]`|
 | `networkPolicy.egressRules[].ports`       | The destination ports for the egress rule                                                                                                                                                |``|
 | `splitBrainDetection.interval`          | Interval between redis sentinel and server split brain checks (in seconds)                                                                                                               |`60`|
+| `splitBrainDetection.resources`         | splitBrainDetection resources                                                                                                                                                            |`{}`|
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 


### PR DESCRIPTION
Add the splitBrainDetection resources field. This is a mandatory field. I did an update from the 4.5.7 version to 4.14.9 and it complained for missing resources on the split brain detection container and it worked after I added it.

#### What this PR does / why we need it:
It shows in the README file that the resource field of the splitBrainDetection is needed.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
