### PR TITLE
[charts/redis-ha] Deploy HAProxy config in IPv4/IPv6 mode

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.15.1
+version: 4.15.2
 appVersion: 6.2.5
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.15.0
+version: 4.15.1
 appVersion: 6.2.5
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/_configs.tpl
+++ b/charts/redis-ha/templates/_configs.tpl
@@ -490,7 +490,7 @@
       timeout check {{ .Values.haproxy.timeout.check }}
 
     listen health_check_http_url
-      bind :8888
+      bind [::]:8888 v4v6
       mode http
       monitor-uri /healthz
       option      dontlognull
@@ -524,15 +524,15 @@
     #master
     frontend ft_redis_master
       {{- if .Values.haproxy.tls.enabled }}
-      bind *:{{ $root.Values.haproxy.containerPort }} ssl crt {{ .Values.haproxy.tls.certMountPath }}{{ .Values.haproxy.tls.keyName }}
+      bind [::]:{{ $root.Values.haproxy.containerPort }} ssl crt {{ .Values.haproxy.tls.certMountPath }}{{ .Values.haproxy.tls.keyName }} v4v6
       {{ else }}
-      bind *:{{ $root.Values.redis.port }}
+      bind [::]:{{ $root.Values.redis.port }} v4v6
       {{- end }}
       use_backend bk_redis_master
     {{- if .Values.haproxy.readOnly.enabled }}
     #slave
     frontend ft_redis_slave
-      bind *:{{ .Values.haproxy.readOnly.port }}
+      bind [::]:{{ .Values.haproxy.readOnly.port }} v4v6
       use_backend bk_redis_slave
     {{- end }}
     # Check all redis servers to see if they think they are master
@@ -584,7 +584,7 @@
     {{- if .Values.haproxy.metrics.enabled }}
     frontend stats
       mode http
-      bind *:{{ .Values.haproxy.metrics.port }}
+      bind [::]:{{ .Values.haproxy.metrics.port }} v4v6
       option http-use-htx
       http-request use-service prometheus-exporter if { path {{ .Values.haproxy.metrics.scrapePath }} }
       stats enable


### PR DESCRIPTION
Instead of listening only on IPv4, this updates the configuration to
start an IPv6 socket that also accepts connections over IPv4 using the
v4v6 flag from
http://cbonte.github.io/haproxy-dconv/2.5/configuration.html#5.1-v4v6

This allows clusters that are in IPv6 only mode (for example, an EKS
cluster) to bring up an HA redis correctly.

#### What this PR does / why we need it:

#### Which issue this PR fixes
  - fixes #98 

#### Special notes for your reviewer:

This requires that we bind to `[::]` with the `v4v6` flag which will create a socket that can accept both IPv4 and IPv6. The other solution is to explicitly bind to both by adding two `bind` statements instead.

Without this change the HA Proxy systems would continue to fail over and over.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
