### PR TITLE
[stable/redis-ha] Fix using pod ip instead of service for announce-ip

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.21.0
+version: 4.21.1
 appVersion: 6.2.5
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
Root problem: Some times separate redis-ha installations hijack slaves from each-other. This occurs when a slave is registered by *pod* ip, not service-ip. And since pod ips are not fixed, the IP may be assigned to another (unfortunately redis) pod ....

A sample `config-init` container log for a bad pod, is as follows: (service cidr is 10.43.0.0/16, pod cidr is 10.42.0.0/16)
```
  Mon May 30 05:25:09 UTC 2022..
Could not connect to Redis at myredis:26379: Try again
Could not connect to Redis at myredis:26379: Try again
Could not connect to Redis at myredis:26379: Try again
  Mon May 30 05:25:54 UTC 2022 Did not find redis master ()
Identify announce ip for this pod..
  using (myredis-announce-0) or (myredis-server-0)
  identified announce (10.42.12.41)
Setting up defaults..
```
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
