### PR TITLE
[charts/redis-ha] Deprecated option http-use-htx

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.16.0
+version: 4.16.1
 appVersion: 6.2.5
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/_configs.tpl
+++ b/charts/redis-ha/templates/_configs.tpl
@@ -585,7 +585,6 @@
     frontend stats
       mode http
       bind [::]:{{ .Values.haproxy.metrics.port }} v4v6
-      option http-use-htx
       http-request use-service prometheus-exporter if { path {{ .Values.haproxy.metrics.scrapePath }} }
       stats enable
       stats uri /stats


### PR DESCRIPTION
Signed-off-by: Turan Asikoglu <874158+trexx@users.noreply.github.com>

#### What this PR does / why we need it:
Deprecated option http-use-htx can prevent HAProxy from starting.  This is cleaning up the last one after it was missed by #196. It was likely missed as it requires the metric exporter be enabled for the configuration to be templated.


#### Checklist
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x ] Chart Version bumped
- [x ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
