### PR TITLE
[charts/redis-ha] Use correct API version of PodDisruptionBudget. (#187)

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.17.3
+version: 4.17.4
 appVersion: 6.2.5
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/_helpers.tpl
+++ b/charts/redis-ha/templates/_helpers.tpl
@@ -81,3 +81,14 @@ Create the name of the service account to use
 {{ required "A valid .Values.redis.masterGroupName entry is required (matching ^[\\w-\\.]+$)" ""}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for poddisruptionbudget.
+*/}}
+{{- define "redis-ha.podDisruptionBudget.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- print "policy/v1" -}}
+{{- else -}}
+{{- print "policy/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/redis-ha/templates/redis-ha-pdb.yaml
+++ b/charts/redis-ha/templates/redis-ha-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ template "redis-ha.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "redis-ha.fullname" . }}-pdb

--- a/charts/redis-ha/templates/redis-haproxy-pdb.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.haproxy.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ template "redis-ha.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "redis-ha.fullname" . }}-haproxy-pdb


### PR DESCRIPTION
Signed-off-by: Mikhail Konyakhin <m.konyahin@gmail.com>

#### What this PR does / why we need it:
Use correct API version of PodDisruptionBudget for k8s equal or above 1.21.0

#### Which issue this PR fixes
  - fixes #187 

#### Special notes for your reviewer:
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md - not needed
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
