### PR TITLE
[charts/redis-ha] Upgrade Redis to 7.0.5 avoid CVE-2022-35951

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.22.2
+version: 4.22.3
 appVersion: 7.0.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -3,7 +3,7 @@
 ##
 image:
   repository: redis
-  tag: 7.0.4-alpine3.16
+  tag: 7.0.5-alpine3.16
   pullPolicy: IfNotPresent
 
 ## Reference to one or more secrets to be used when pulling images


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

#### What this PR does / why we need it:

Upgrade Redis to 7.0.5 to avoid CVE-2022-35951



#### Special notes for your reviewer:
Refer to [GHSA-5gc4-76rx-22c9](https://github.com/redis/redis/security/advisories/GHSA-5gc4-76rx-22c9) for more details.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
