### PR TITLE
[stable/redis-ha] add containerSecurityContext to redis-exporter container

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.22.3
+version: 4.22.4
 appVersion: 7.0.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -455,6 +455,7 @@ spec:
         {{- range $key, $value := .Values.exporter.extraArgs }}
           - --{{ $key }}={{ $value }}
         {{- end }}
+        securityContext: {{ toYaml .Values.containerSecurityContext | nindent 10 }}        
         env:
           - name: REDIS_ADDR
           {{- if .Values.exporter.sslEnabled }}


### PR DESCRIPTION

#### What this PR does / why we need it:

It adds securityContext to the redis-exporter container in redis-ha-sts

#### Special notes for your reviewer:

Same securityContext as in other containers

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

Signed-off-by: Toni Tauro <toni.tauro@adfinis.com>
