### PR TITLE
[charts/redis-ha] Remove HAproxy revision label

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.22.4
+version: 4.22.5
 appVersion: 7.0.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-haproxy-deployment.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-deployment.yaml
@@ -24,7 +24,6 @@ spec:
       labels:
         app: {{ template "redis-ha.name" . }}-haproxy
         release: {{ .Release.Name }}
-        revision: "{{ .Release.Revision }}"
         {{- range $key, $value := .Values.haproxy.labels }}
         {{ $key }}: {{ $value | toString }}
         {{- end }}
@@ -69,7 +68,6 @@ spec:
                 matchLabels:
                   app: {{ template "redis-ha.name" . }}-haproxy
                   release: {{ .Release.Name }}
-                  revision: "{{ .Release.Revision }}"
               topologyKey: kubernetes.io/hostname
     {{- else }}
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -79,7 +77,6 @@ spec:
                   matchLabels:
                     app: {{ template "redis-ha.name" . }}-haproxy
                     release: {{ .Release.Name }}
-                    revision: "{{ .Release.Revision }}"
                 topologyKey: kubernetes.io/hostname
     {{- end }}
     {{- end }}
@@ -92,7 +89,6 @@ spec:
           matchLabels:
             app: {{ template "redis-ha.name" . }}-haproxy
             release: {{ .Release.Name }}
-            revision: "{{ .Release.Revision }}"
       {{- end }}
       initContainers:
       - name: config-init

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -78,7 +78,7 @@ haproxy:
   readOnly:
     enabled: false
     port: 6380
-  replicas: 2
+  replicas: 3
   image:
     repository: haproxy
     tag: 2.6.4

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -78,7 +78,7 @@ haproxy:
   readOnly:
     enabled: false
     port: 6380
-  replicas: 3
+  replicas: 2
   image:
     repository: haproxy
     tag: 2.6.4


### PR DESCRIPTION
#### What this PR does / why we need it:
Where this label come from: DandyDeveloper/charts#6

This label causes two main problems for us:
- `helm-diff` plugin is not working correctly
- all changes on a chart that uses redis-ha as dependency triggers a redeployment of HAproxy pods.

If we reduce number of replicas to 2 in HAproxy we can allow clusters of 3 nodes upgrade without having any of this issues.

Another option in that case can be just to disable `hardAntiAffinity`.

#### Which issue this PR fixes
  - fixes #189

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
