### PR TITLE
fix: publishNotReadyAddresses K8s version check

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.22.4
+version: 4.22.5
 appVersion: 7.0.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.22.5
+version: 4.22.6
 appVersion: 7.0.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-announce-service.yaml
+++ b/charts/redis-ha/templates/redis-ha-announce-service.yaml
@@ -15,12 +15,16 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   annotations:
+{{- if (semverCompare "<=1.10-0" $.Capabilities.KubeVersion.GitVersion) }}
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+{{- end }}
   {{- if $root.Values.serviceAnnotations }}
 {{ toYaml $root.Values.serviceAnnotations | indent 4 }}
   {{- end }}
 spec:
+{{- if (semverCompare ">=1.11-0" $.Capabilities.KubeVersion.GitVersion) }}
   publishNotReadyAddresses: true
+{{- end }}
   type: ClusterIP
   ports:
   {{- if ne (int $root.Values.redis.port) 0 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

The annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"` is deprecated since Kubernetes 1.11, following https://github.com/kubernetes/kubernetes/pull/63742 The template input both fields, the annotation and the substituted field `.spec.publishNotReadyAddresses=True` but it becomes incompatible with Kubernetes <=1.10 so a check Kubernetes version resolve it put the right fields based on Kubernetes version.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
