### PR TITLE
[stable/redis-ha] 🐛 fix: better kubectl commands in NOTES

### DIFF
--- a/charts/redis-ha/templates/NOTES.txt
+++ b/charts/redis-ha/templates/NOTES.txt
@@ -9,7 +9,7 @@ To connect to your Redis server:
 
 2. Connect to the Redis master pod that you can use as a client. By default the {{ template "redis-ha.fullname" . }}-server-0 pod is configured as the master:
 
-   kubectl exec -it {{ template "redis-ha.fullname" . }}-server-0 sh -n {{ .Release.Namespace }}
+   kubectl exec -it {{ template "redis-ha.fullname" . }}-server-0 -n {{ .Release.Namespace }} -c redis -- sh
 
 3. Connect using the Redis CLI (inside container):
 
@@ -17,7 +17,7 @@ To connect to your Redis server:
 {{- else }}
 1. Run a Redis pod that you can use as a client:
 
-   kubectl exec -it {{ template "redis-ha.fullname" . }}-server-0 sh -n {{ .Release.Namespace }}
+   kubectl exec -it {{ template "redis-ha.fullname" . }}-server-0 -n {{ .Release.Namespace }} -c redis -- sh
 
 2. Connect using the Redis CLI:
 


### PR DESCRIPTION
#### What this PR does / why we need it:

this pr will fix deprecation warnings in `kubectl` commands and also specifying container name in `exec` command

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
