### PR TITLE
[stable/redis-ha] set default haproxy image to alpine build, fix issu…

### DIFF
--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -81,7 +81,7 @@ haproxy:
   replicas: 3
   image:
     repository: haproxy
-    tag: 2.6.9
+    tag: 2.6.9-alpine
     pullPolicy: IfNotPresent
 
   ## Custom labels for the haproxy pod


### PR DESCRIPTION
…e #248.

#### What this PR does / why we need it:
change default haproxy image tag to alpine build as that build has less security issues

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #248

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
