### PR TITLE
Update GHA to use updated versions and non-deprecated publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,13 +3,27 @@ on:
   push:
     branches: [ master ]
 jobs:
-  build:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Package and Publish charts
-      uses: J12934/helm-gh-pages-action@master
-      with:
-        deploy-branch: gh-pages
-        access-token: "${{ secrets.CR_TOKEN }}"
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.CR_TOKEN }}"


### PR DESCRIPTION
#### What this PR does / why we need it:
Looks like publishing the latest version of the chart failed. Not sure if it was related to checking out `actions/checkout@v2` but it could use the updating. That's when I also noticed the helm chart releaser was archived and so I switched to the more official recommended solution.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
