### PR TITLE
[dandydev/redis-ha] Add TERM signal trap to Redis-ha fix-split-brain.sh to prevent infinite loop and gracefully exit

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.26.1
+version: 4.26.2
 appVersion: 7.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/_configs.tpl
+++ b/charts/redis-ha/templates/_configs.tpl
@@ -459,6 +459,7 @@
         identify_announce_ip
     done
 
+    trap "exit 0" TERM
     while true; do
         sleep {{ .Values.splitBrainDetection.interval }}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

When

-  A restart occurs for a redis pod
-  Some modification (like resource increase) occurs 
-  draining a node

The command fix-split-brain.sh container will not gracefully exit and goes into an infinite loop and will not be stopped until terminationGracePeriodSeconds timeouts. In this commit a TERM signal trap is added to prevent such a infinite loop and gracefully exit fix-split-brain.sh

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
