### PR TITLE
feat: Add ability to define priorityClassName globally

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.26.6
+version: 4.27.0
 appVersion: 7.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/README.md
+++ b/charts/redis-ha/README.md
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the Redis chart and the
 
 | Parameter                 | Description                                                                                                                                                                                              | Default                                                                                    |
 |:--------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------------|
+| `global.priorityClassName`| Default priority class for all components (HAProxy Deployment and Redis StatefulSet)                                                                                                                     | `""`                                                                                       |
 | `image.repository`        | Redis image repository                 | `redis`                                                                                  |
 | `image.tag`        | Redis image tag                            | `6.2.5-alpine`                                                                              |
 | `image.pullPolicy`        | Redis image pull policy                          | `IfNotPresent`                                                                   |

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -520,9 +520,9 @@ spec:
 {{- if .Values.extraContainers }}
 {{- toYaml .Values.extraContainers | nindent 6 }}
 {{- end -}}
-{{- if .Values.priorityClassName }}
+      {{- with .Values.priorityClassName | default .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
-{{- end }}
+      {{- end }}
       volumes:
       - name: config
         configMap:

--- a/charts/redis-ha/templates/redis-haproxy-deployment.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-deployment.yaml
@@ -178,9 +178,9 @@ spec:
 {{- end }}
         lifecycle:
 {{ toYaml .Values.haproxy.lifecycle | indent 10 }}
-{{- if .Values.haproxy.priorityClassName }}
-      priorityClassName: {{ .Values.haproxy.priorityClassName }}
-{{- end }}
+      {{- with .Values.haproxy.priorityClassName | default .Values.global.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       volumes:
 {{- if .Values.haproxy.tls.enabled }}
       - name: pemfile

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -1,3 +1,8 @@
+## Globally shared configuration
+global:
+  # -- Default priority class for all components
+  priorityClassName: ""
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:

Context is this feature request over there:
- https://github.com/argoproj/argo-helm/issues/2704

`.Values.global.xyz` is a reserved section which is passed to all dependency charts inside a helm chart (also called subcharts).

Implementing this is useful for both
- direct deployment of this helm chart
- use `redis-ha` as a dependency chart (like we do in argoproj/argo-helm)

#### Which issue this PR fixes

Partially this one over there:
- https://github.com/argoproj/argo-helm/issues/2704

#### Special notes for your reviewer:

Other well-known charts implementing this:
- [grafana/loki](https://github.com/grafana/loki)
- [grafana/helm-charts](https://github.com/grafana/helm-charts)
- [dapr/dapr](https://github.com/dapr/dapr)
- [argoproj/argo-helm](https://github.com/argoproj/argo-helm)
- [istio/istio](https://github.com/istio/istio)
- ...?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
