### PR TITLE
[stable/redis-ha]: Allow DNS requests to local network

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.27.6
+version: 4.27.7
 appVersion: 7.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-network-policy.yaml
+++ b/charts/redis-ha/templates/redis-ha-network-policy.yaml
@@ -35,15 +35,6 @@ spec:
           protocol: TCP
         - port: {{ .Values.sentinel.port }}
           protocol: TCP
-    - to:
-      - namespaceSelector: {}
-      - ipBlock:
-          cidr: 169.254.0.0/16
-      ports:
-        - port: 53
-          protocol: UDP
-        - port: 53
-          protocol: TCP
 {{-  range $rule := .Values.networkPolicy.egressRules }}
     - to:
 {{ (tpl (toYaml $rule.selectors) $) | indent 7 }}

--- a/charts/redis-ha/templates/redis-ha-network-policy.yaml
+++ b/charts/redis-ha/templates/redis-ha-network-policy.yaml
@@ -37,6 +37,8 @@ spec:
           protocol: TCP
     - to:
       - namespaceSelector: {}
+      - ipBlock:
+          cidr: 169.254.0.0/16
       ports:
         - port: 53
           protocol: UDP

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -756,7 +756,20 @@ networkPolicy:
     #       protocol: TCP
 
   ## user can define egress rules too, uses the same structure as ingressRules
-  egressRules: []
+  egressRules:
+    - selectors:
+      # allow all destinations for DNS traffic
+      - namespaceSelector: {}
+      - ipBlock:
+          # Cloud Provider often uses the local link local range to host managed DNS resolvers.
+          # We need to allow this range to ensure that the Redis pods can resolve DNS.
+          # Example architecture for GCP Cloud DNS: https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-dns#architecture
+          cidr: 169.254.0.0/16
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
 
 splitBrainDetection:
   interval: 60


### PR DESCRIPTION
- In some situations (GKE cluster with [Cloud DNS](https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-dns#architecture)), the DNS server is configured on the local network IP range (169.254.0.0/16), so we should allow this CIDR in the default network policy.