### PR TITLE
[stable/redis-ha]: add ability to disable default redis config

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: redis-ha
 home: http://redis.io/
 keywords:
-- redis
-- keyvalue
-- database
-version: 4.27.1
+  - redis
+  - keyvalue
+  - database
+version: 4.27.2
 appVersion: 7.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png
 maintainers:
-- email: salimsalaues@gmail.com
-  name: ssalaues
-- email: aaron.layfield@gmail.com
-  name: dandydeveloper
+  - email: salimsalaues@gmail.com
+    name: ssalaues
+  - email: aaron.layfield@gmail.com
+    name: dandydeveloper
 sources:
-- https://redis.io/download
-- https://github.com/DandyDeveloper/charts/blob/master/charts/redis-ha
-- https://github.com/oliver006/redis_exporter
+  - https://redis.io/download
+  - https://github.com/DandyDeveloper/charts/blob/master/charts/redis-ha
+  - https://github.com/oliver006/redis_exporter

--- a/charts/redis-ha/templates/_configs.tpl
+++ b/charts/redis-ha/templates/_configs.tpl
@@ -27,6 +27,9 @@
     {{- end }}
     {{- end }}
     {{- range $key, $value := .Values.redis.config }}
+    {{- if not $value }}
+        {{ continue }}
+    {{- end}}
     {{- if kindIs "slice" $value }}
         {{- range $value }}
     {{ $key }} {{ . }}

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -111,7 +111,8 @@ haproxy:
   ## Pod Disruption Budget
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
-  podDisruptionBudget: {}
+  podDisruptionBudget:
+    {}
     # Use only one of the two
     # maxUnavailable: 1
     # minAvailable: 1
@@ -183,7 +184,7 @@ haproxy:
       type: RuntimeDefault
     capabilities:
       drop:
-      - ALL
+        - ALL
 
   ## Whether the haproxy pods should be forced to run on separate nodes.
   hardAntiAffinity: true
@@ -197,10 +198,10 @@ haproxy:
   ## Custom config-haproxy.cfg files used to override default settings. If this file is
   ## specified then the config-haproxy.cfg above will be ignored.
   # customConfig: |-
-    # Define configuration here
+  # Define configuration here
   ## Place any additional configuration section to add to the default config-haproxy.cfg
   # extraConfig: |-
-    # Define configuration here
+  # Define configuration here
 
   ## Container lifecycle hooks
   ## Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
@@ -221,7 +222,8 @@ haproxy:
     labels: {}
     ## user defines ingress rules that Haproxy should permit into
     ## uses the format defined in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-    ingressRules: []
+    ingressRules:
+      []
       # - selectors:
       #   - namespaceSelector:
       #       matchLabels:
@@ -267,7 +269,7 @@ sysctlImage:
 ## Redis specific configuration options
 redis:
   port: 6379
-  masterGroupName: "mymaster"       # must match ^[\\w-\\.]+$) and can be templated
+  masterGroupName: "mymaster" # must match ^[\\w-\\.]+$) and can be templated
 
   customCommand: []
   # - bash
@@ -313,10 +315,11 @@ redis:
   config:
     ## Additional redis conf options can be added below
     ## For all available options see http://download.redis.io/redis-stable/redis.conf
+    ## To disable an option, provide an empty string (e.g., save: "")
     min-replicas-to-write: 1
-    min-replicas-max-lag: 5   # Value in seconds
-    maxmemory: "0"       # Max memory to use for each redis instance. Default is unlimited.
-    maxmemory-policy: "volatile-lru"  # Max memory policy to use for each redis instance. Default is volatile-lru.
+    min-replicas-max-lag: 5 # Value in seconds
+    maxmemory: "0" # Max memory to use for each redis instance. Default is unlimited.
+    maxmemory-policy: "volatile-lru" # Max memory policy to use for each redis instance. Default is volatile-lru.
     # Determines if scheduled RDB backups are created. Default is false.
     # Please note that local (on-disk) RDBs will still be created when re-syncing with a new slave. The only way to prevent this is to enable diskless replication.
     save: "900 1"
@@ -328,7 +331,7 @@ redis:
   ## Custom redis.conf files used to override default settings. If this file is
   ## specified then the redis.config above will be ignored.
   # customConfig: |-
-    # Define configuration here
+  # Define configuration here
 
   resources: {}
   #  requests:
@@ -418,7 +421,7 @@ sentinel:
   ## Custom sentinel.conf files used to override default settings. If this file is
   ## specified then the sentinel.config above will be ignored.
   # customConfig: |-
-    # Define configuration here
+  # Define configuration here
 
   resources: {}
   #  requests:
@@ -449,7 +452,7 @@ containerSecurityContext:
     type: RuntimeDefault
   capabilities:
     drop:
-    - ALL
+      - ALL
 
   ## Assuming your kubelet allows it, you can the following instructions to configure
   ## specific sysctl parameters
@@ -602,7 +605,8 @@ exporter:
     periodSeconds: 15
     successThreshold: 2
 
-podDisruptionBudget: {}
+podDisruptionBudget:
+  {}
   # Use only one of the two
   # maxUnavailable: 1
   # minAvailable: 1
@@ -703,7 +707,8 @@ prometheusRule:
   # prometheusRule.interval -- How often rules in the group are evaluated (falls back to `global.evaluation_interval` if not set).
   interval: 10s
   # prometheusRule.rules -- Rules spec template (see https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule).
-  rules: []
+  rules:
+    []
     # Example:
     # - alert: RedisPodDown
     #   expr: |
@@ -736,7 +741,8 @@ networkPolicy:
   labels: {}
   ## user defines ingress rules that Redis should permit into
   ## uses the format defined in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-  ingressRules: []
+  ingressRules:
+    []
     # - selectors:
     #   - namespaceSelector:
     #       matchLabels:


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
When we need to disable a default Redis configuration option, such as the `save` option, commenting it out isn't effective because it gets overwritten by the default chart values. This PR provides a solution by allowing you to assign an empty string to that option, ensuring it is skipped when rendering Helm templates.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
