### PR TITLE
[chart/redis-ha] redis-ha-statefulset: bugfix StatefulSet priorityClassName

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.27.2
+version: 4.27.3
 appVersion: 7.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -529,7 +529,7 @@ spec:
 {{- toYaml .Values.extraContainers | nindent 6 }}
 {{- end -}}
       {{- with .Values.priorityClassName | default .Values.global.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       volumes:
       - name: config


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
`global.priorityClassName` or `priorityClassName` will cause an error in the output of Redis-ha's StatefulSet.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
