### PR TITLE
[stable/redis-ha]: add redis source to restore options

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.29.3
+version: 4.29.4
 appVersion: 7.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.29.4
+version: 4.30.0
 appVersion: 7.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -1,5 +1,6 @@
 {{- $regexRestoreS3 := "^s3://.+|^S3://.+" -}}
 {{- $regexRestoreSSH := "^.+@.+:.+" -}}
+{{- $regexRestoreRedis := "^redis://(?:[A-Za-z0-9_]+(?::[^@]+)?@)?[A-Za-z0-9.-]+(?::\\d{1,5})?(?:/\\d+)?$" -}}
 
 apiVersion: apps/v1
 kind: StatefulSet
@@ -242,6 +243,34 @@ spec:
           {{- else }}
             name: {{ include "redis-ha.fullname" . }}-secret
           {{- end }}
+        volumeMounts:
+        - name: data
+          mountPath: /data
+{{- end }}
+{{ if regexFind $regexRestoreRedis (toString .Values.restore.redis.source) }}
+      - name: restore-redis
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.init.resources | indent 10 }}
+        command:
+        - sh
+        args:
+        - "-c"
+        - "echo $HOSTNAME | grep -q 'ha-server-0' \
+          && nc -w 5 -vz {{ regexReplaceAll  "^redis:\\/\\/(.*)" .Values.restore.redis.source "${1}" }} \
+          && test ! -s /data/dump.rdb \
+          && timeout {{ .Values.restore.timeout }} \
+          redis-cli -u {{ .Values.restore.redis.source }} --rdb /data/dump.rdb_ \
+          && test -s /data/dump.rdb_ \
+          && if test -s /data/dump.rdb; \
+              then cp -v /data/dump.rdb /data/dump.rdb_orig; fi \
+          && mv -v /data/dump.rdb_ /data/dump.rdb || true"
+        {{- if .Values.restore.existingSecret }}
+        envFrom:
+        - secretRef:
+            name: {{ .Values.existingSecret }}
+        {{- end }}
         volumeMounts:
         - name: data
           mountPath: /data

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -889,6 +889,8 @@ tls:
 # EXAMPLE source for s3 restore: 's3://bucket/dump.rdb'
 # REQUIRED for ssh restore: 'key' should be in one line including CR i.e. '-----BEGIN RSA PRIVATE KEY-----\n...\n...\n...\n-----END RSA PRIVATE KEY-----'
 # EXAMPLE source for ssh restore: 'user@server:/path/dump.rdb'
+# REQUIRED for redis restore: 'source' should be in form of redis connection uri: 'redis://[username:password@]host:port[/db]'
+# EXAMPLE source for redis restore: 'redis://username:password@localhost:6379'
 restore:
   # -- Timeout for the restore
   timeout: 600
@@ -914,6 +916,8 @@ restore:
     # Key should be in one line separated with \n.
     # i.e. `-----BEGIN RSA PRIVATE KEY-----\n...\n...\n-----END RSA PRIVATE KEY-----`
     key: ""
+  redis:
+    source: ""
 
 ## Custom PrometheusRule to be defined
 ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds support for using a remote Redis instance as a data source for restoration. It utilizes the `redis-cli --rdb` command to perform the restore operation.

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
