### PR TITLE
[stable/redis-ha]: support pod annotations on the test-ha pod

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.34.7
+version: 4.34.8
 appVersion: 8.2.1
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png

--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.29.4
+version: 4.29.5
 appVersion: 7.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/tests/test-redis-ha-pod.yaml
+++ b/charts/redis-ha/templates/tests/test-redis-ha-pod.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
 {{ include "labels.standard" . | indent 4 }}
   annotations:
+  {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 4 }}
+  {{- end }}
     "helm.sh/hook": test-success
 spec:
   nodeSelector:


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows setting pod annotations on the test pod.

#### Which issue this PR fixes
https://github.com/DandyDeveloper/charts/issues/304

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)