### PR TITLE
[stable/redis-ha]: allow DNS requests to CIDR 169.254.0.0/16 in haproxy NetworkPolicy

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.29.4
+version: 4.29.5
 appVersion: 7.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-haproxy-network-policy.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-network-policy.yaml
@@ -37,6 +37,11 @@ spec:
           protocol: TCP
     - to:
         - namespaceSelector: {}
+        - ipBlock:
+            # Cloud Provider often uses the local link local range to host managed DNS resolvers.
+            # We need to allow this range to ensure that the Redis pods can resolve DNS.
+            # Example architecture for GCP Cloud DNS: https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-dns#architecture
+            cidr: 169.254.0.0/16
       ports:
         - port: 53
           protocol: UDP


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds a rule to the redis-ha haproxy NetworkPolicy to allow haproxy pods to send DNS requests to CIDR 169.254.0.0/16.

This rule is already present in the redis-ha NetworkPolicy.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
