### PR TITLE
redis-ha: minor updates to haproxy and redis_exporter versions

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.30.0
+version: 4.31.0
 appVersion: 7.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -127,7 +127,7 @@ haproxy:
     # -- HAProxy Image Repository
     repository: public.ecr.aws/docker/library/haproxy
     # -- HAProxy Image Tag
-    tag: 2.9.4-alpine
+    tag: 3.0.7-alpine
     # -- HAProxy Image PullPolicy
     pullPolicy: IfNotPresent
 
@@ -700,9 +700,9 @@ exporter:
   # -- If `true`, the prometheus exporter sidecar is enabled
   enabled: false
   # -- Exporter image
-  image: oliver006/redis_exporter
+  image: quay.io/oliver006/redis_exporter
   # -- Exporter image tag
-  tag: v1.57.0
+  tag: v1.67.0
   # -- Exporter image pullPolicy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
#### What this PR does / why we need it:

- Updates HAProxy to 3.0.x, which is the latest version of the current LTS branch (2.9 was not and will be EOL 2025-Q1; see https://haproxy.org/)
- Updates redis_exporter to the latest version; also, the author now publishes official images to quay.io in addition to Docker Hub (see https://github.com/oliver006/redis_exporter/issues/537)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
