### PR TITLE
fix(redis-ha): match pdb selectors with sts selectors

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.33.6
+version: 4.33.7
 appVersion: 7.2.7
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-pdb.yaml
+++ b/charts/redis-ha/templates/redis-ha-pdb.yaml
@@ -12,9 +12,6 @@ metadata:
 spec:
   selector:
     matchLabels:
-      # The replica label is set on StatefulSet pods but not the Test pods
-      # We want to avoid including the Test pods in the budget
-      {{ template "redis-ha.fullname" . }}: replica
       release: {{ .Release.Name }}
       app: {{ template "redis-ha.name" . }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -20,6 +20,7 @@ spec:
     matchLabels:
       release: {{ .Release.Name }}
       app: {{ template "redis-ha.name" . }}
+      {{ template "redis-ha.fullname" . }}: replica
   serviceName: {{ template "redis-ha.fullname" . }}
   replicas: {{ .Values.replicas }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -8,7 +8,6 @@ metadata:
   name: {{ template "redis-ha.fullname" . }}-server
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    {{ template "redis-ha.fullname" . }}: replica
     {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ template "redis-ha.fullname" . }}-server
   namespace: {{ .Release.Namespace | quote }}
   labels:
+    {{ template "redis-ha.fullname" . }}: replica
     {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -19,7 +19,6 @@ spec:
     matchLabels:
       release: {{ .Release.Name }}
       app: {{ template "redis-ha.name" . }}
-      {{ template "redis-ha.fullname" . }}: replica
   serviceName: {{ template "redis-ha.fullname" . }}
   replicas: {{ .Values.replicas }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes the following message on GKE:

> StatefulSet doesn't have a Pod Disruption Budget. This means that all Pods in the StatefulSet might experience simultaneous disruption during scenarios like node upgrades

#### Which issue this PR fixes
  - fixes #307

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
