### PR TITLE
[stable/redis-ha] Bump shellcheck in order to fix arm64 deployment

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.32.0
+version: 4.33.0
 appVersion: 7.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/README.md
+++ b/charts/redis-ha/README.md
@@ -67,9 +67,9 @@ The following table lists the configurable parameters of the Redis chart and the
 | `auth` | Configures redis with AUTH (requirepass & masterauth conf params) | bool | `false` |
 | `authKey` | Defines the key holding the redis password in existing secret. | string | `"auth"` |
 | `configmap.labels` | Custom labels for the redis configmap | object | `{}` |
-| `configmapTest.image` | Image for redis-ha-configmap-test hook | object | `{"repository":"koalaman/shellcheck","tag":"v0.5.0"}` |
+| `configmapTest.image` | Image for redis-ha-configmap-test hook | object | `{"repository":"koalaman/shellcheck","tag":"v0.10.0"}` |
 | `configmapTest.image.repository` | Repository of the configmap shellcheck test image. | string | `"koalaman/shellcheck"` |
-| `configmapTest.image.tag` | Tag of the configmap shellcheck test image. | string | `"v0.5.0"` |
+| `configmapTest.image.tag` | Tag of the configmap shellcheck test image. | string | `"v0.10.0"` |
 | `configmapTest.resources` | Resources for the ConfigMap test pod | object | `{}` |
 | `containerSecurityContext` | Security context to be added to the Redis containers. | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` |
 | `emptyDir` | Configuration of `emptyDir`, used only if persistentVolume is disabled and no hostPath specified | object | `{}` |

--- a/charts/redis-ha/templates/_configs.tpl
+++ b/charts/redis-ha/templates/_configs.tpl
@@ -333,7 +333,7 @@
     identify_announce_ip
 
     if [ -z "${ANNOUNCE_IP}" ]; then
-        "Error: Could not resolve the announce ip for this pod."
+        "Error: Could not resolve the announce ip for this pod"
         exit 1
     elif [ "${MASTER}" ]; then
         find_master

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -70,7 +70,7 @@ configmapTest:
     # -- Repository of the configmap shellcheck test image.
     repository: koalaman/shellcheck
     # -- Tag of the configmap shellcheck test image.
-    tag: v0.5.0
+    tag: v0.10.0
   # -- Resources for the ConfigMap test pod
   resources: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
This fixes the issue that I'm unable to deploy the helm chart on arm64 nodes. This is due to v0.5.0 does not support arm64
https://hub.docker.com/r/koalaman/shellcheck/tags

#### Special notes for your reviewer:

After bumping just the shellcheck version I got this new error:

```

In /readonly-config/init.sh line 239:
    "Error: Could not resolve the announce ip for this pod."
    ^-- SC2288 (warning): This is interpreted as a command name ending with '.'. Double check syntax.

For more information:
  https://www.shellcheck.net/wiki/SC2288 -- This is interpreted as a command ...
stream closed EOF for argocd/argocd-redis-ha-configmap-test (check-init)

```

So I just removed that dot.



#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
