### PR TITLE
[stable/redis-ha] renamed redis-ha value "fullNameOverride" to "fullnameOverride" 

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.33.4
+version: 4.33.5
 appVersion: 7.2.7
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/README.md
+++ b/charts/redis-ha/README.md
@@ -78,7 +78,7 @@ The following table lists the configurable parameters of the Redis chart and the
 | `extraInitContainers` | Extra init containers to include in StatefulSet | list | `[]` |
 | `extraLabels` | Labels added here are applied to all created resources | object | `{}` |
 | `extraVolumes` | Extra volumes to include in StatefulSet | list | `[]` |
-| `fullNameOverride` | Full name of the Redis HA Resources | string | `""` |
+| `fullnameOverride` | Full name of the Redis HA Resources | string | `""` |
 | `global.compatibility` | Openshift compatibility options | object | `{"openshift":{"adaptSecurityContext":"auto"}}` |
 | `global.priorityClassName` | Default priority class for all components | string | `""` |
 | `hardAntiAffinity` | Whether the Redis server pods should be forced to run on separate nodes. # This is accomplished by setting their AntiAffinity with requiredDuringSchedulingIgnoredDuringExecution as opposed to preferred. # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature | bool | `true` |

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -19,7 +19,7 @@ image:
   pullPolicy: IfNotPresent
 
 # -- Full name of the Redis HA Resources
-fullNameOverride: ""
+fullnameOverride: ""
 
 # -- Name override for Redis HA resources
 nameOverride: ""


### PR DESCRIPTION

#### What this PR does / why we need it:
fixes uneffective value "fullNameOverride" in redis-ha chart, which is spelled differently in helpers.tpl file

#### Which issue this PR fixes
  - fixes #325 


