### PR TITLE
[stable/redis-ha] add sentinel announce-hosts and resolve-hosts

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.34.13
+version: 4.34.14
 appVersion: 8.2.1
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png

--- a/charts/redis-ha/README.md
+++ b/charts/redis-ha/README.md
@@ -216,6 +216,8 @@ The following table lists the configurable parameters of the Redis chart and the
 | `sentinel.livenessProbe.successThreshold` | Success threshold for liveness probe | int | `1` |
 | `sentinel.livenessProbe.timeoutSeconds` | Timeout seconds for liveness probe | int | `15` |
 | `sentinel.password` | A password that configures a `requirepass` in the conf parameters (Requires `sentinel.auth: enabled`) | string | `nil` |
+| `sentinel.resolveHostnames` | Configures sentinel with resolve-hostnames parameter, if true sets "resolve-hostnames yes" in sentinel.conf | bool | `nil` |
+| `sentinel.announceHostnames` | Configures sentinel with announce-hostnames parameter, if true sets "announce-hostnames yes" in sentinel.conf | bool | `nil` |
 | `sentinel.port` | Port to access the sentinel service | int | `26379` |
 | `sentinel.quorum` | Minimum number of nodes expected to be live. | int | `2` |
 | `sentinel.readinessProbe.enabled` |  | bool | `true` |

--- a/charts/redis-ha/templates/_configs.tpl
+++ b/charts/redis-ha/templates/_configs.tpl
@@ -68,9 +68,9 @@
     {{- end }}
     {{- range $key, $value := .Values.sentinel.config }}
     {{- if eq "maxclients" $key  }}
-        {{ $key }} {{ $value }}
+    {{ $key }} {{ $value }}
     {{- else }}
-        sentinel {{ $key }} {{ template "redis-ha.masterGroupName" $ }} {{ $value }}
+    sentinel {{ $key }} {{ template "redis-ha.masterGroupName" $ }} {{ $value }}
     {{- end }}
     {{- end }}
 {{- if .Values.auth }}
@@ -78,6 +78,12 @@
 {{- end }}
 {{- if .Values.sentinel.auth }}
     requirepass replace-default-sentinel-auth
+{{- end }}
+{{- if .Values.sentinel.resolveHostnames }}
+    sentinel resolve-hostnames yes
+{{- end }}
+{{- if .Values.sentinel.announceHostnames }}
+    sentinel announce-hostnames yes
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -532,6 +532,14 @@ sentinel:
   password: ~
   # password: password
 
+  # -- (bool) Configures sentinel with resolve-hostnames parameter, if true sets "resolve-hostnames yes" in sentinel.conf
+  resolveHostnames: ~
+  # resolveHostnames: true
+
+  # -- (bool) Configures sentinel with announce-hostnames parameter, if true sets "announce-hostnames yes" in sentinel.conf
+  announceHostnames: ~
+  # announceHostnames: true
+
   # -- An existing secret containing a key defined by `sentinel.authKey` that configures `requirepass`
   # in the conf parameters (Requires `sentinel.auth: enabled`, cannot be used in conjunction with `.Values.sentinel.password`)
   # Supports templates like "{{ .Release.Name }}-sentinel-creds"


### PR DESCRIPTION
#### What this PR does / why we need it:
* add `sentinel announce-hosts` and `sentinel resolve-hosts` enabling values.
* streamline `sentinel.conf` indentation.
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #354

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
