### PR TITLE
[stable/redis-ha] added releaseOverride (#372)

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.35.5
+version: 4.35.6
 appVersion: 8.2.2
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png

--- a/charts/redis-ha/README.md
+++ b/charts/redis-ha/README.md
@@ -156,6 +156,7 @@ The following table lists the configurable parameters of the Redis chart and the
 | `redis.tlsReplication` | Configures redis with tls-replication parameter, if true sets "tls-replication yes" in redis.conf | bool | `nil` |
 | `redis.updateStrategy` | Update strategy for Redis StatefulSet # ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies | object | `{"type":"RollingUpdate"}` |
 | `redisPassword` | A password that configures a `requirepass` and `masterauth` in the conf parameters (Requires `auth: enabled`) | string | `nil` |
+| `releaseOverride` | Release name override for Redis HA resources | string | `""` |
 | `replicas` | Number of redis master/slave | int | `3` |
 | `restore.existingSecret` | Set existingSecret to true to use secret specified in existingSecret above | bool | `false` |
 | `restore.redis.source` |  | string | `""` |

--- a/charts/redis-ha/templates/tests/test-redis-ha-pod.yaml
+++ b/charts/redis-ha/templates/tests/test-redis-ha-pod.yaml
@@ -17,7 +17,7 @@ spec:
   tolerations:
 {{ toYaml .Values.tolerations | indent 4 }}
   containers:
-  - name: "{{ .Release.Name }}-service-test"
+  - name: "{{ default .Release.Name (.Values.releaseOverride) }}-service-test"
     image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
     command:
       - sh

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -24,6 +24,9 @@ fullnameOverride: ""
 # -- Name override for Redis HA resources
 nameOverride: ""
 
+# -- Release name override for Redis HA resources
+releaseOverride: ""
+
 ## Reference to one or more secrets to be used when pulling images
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 ## This imagePullSecrets is only for redis images


### PR DESCRIPTION
#### What this PR does / why we need it:
The field `{{ .Release.Name }}` can contain dots, but container names with dots are not allowed

#### Which issue this PR fixes
fixes #372

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
