### PR TITLE
stable/redis-ha: add haproxy.globalConfig parameter

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.35.7
+version: 4.35.8
 appVersion: 8.2.2
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png

--- a/charts/redis-ha/README.md
+++ b/charts/redis-ha/README.md
@@ -256,6 +256,7 @@ The following table lists the configurable parameters of the Redis chart and the
 | `haproxy.emptyDir` | Configuration of `emptyDir` | object | `{}` |
 | `haproxy.enabled` | Enabled HAProxy LoadBalancing/Proxy | bool | `false` |
 | `haproxy.extraConfig` | Allows to place any additional configuration section to add to the default config-haproxy.cfg | string | `nil` |
+| `haproxy.globalConfig` | Allows to place HAProxy global section configuration. Inserted before defaults section. | string | `nil` |
 | `haproxy.hardAntiAffinity` | Whether the haproxy pods should be forced to run on separate nodes. | bool | `true` |
 | `haproxy.image.pullPolicy` | HAProxy Image PullPolicy | string | `"IfNotPresent"` |
 | `haproxy.image.repository` | HAProxy Image Repository | string | `"public.ecr.aws/docker/library/haproxy"` |

--- a/charts/redis-ha/templates/_configs.tpl
+++ b/charts/redis-ha/templates/_configs.tpl
@@ -543,6 +543,10 @@
 {{- if .Values.haproxy.customConfig }}
 {{ tpl .Values.haproxy.customConfig . | indent 4 }}
 {{- else }}
+{{- if .Values.haproxy.globalConfig }}
+    # Global configuration
+{{ tpl .Values.haproxy.globalConfig . | indent 4 }}
+{{- end }}
     defaults REDIS
       mode tcp
       timeout connect {{ .Values.haproxy.timeout.connect }}

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -287,6 +287,15 @@ haproxy:
   # customConfig: |-
     # Define configuration here
 
+  ## Global HAProxy configuration section. This is inserted before the 'defaults' section.
+  ## Use this to configure global HAProxy settings like logging, performance tuning, etc.
+  # -- (string) Allows to place HAProxy global section configuration. Inserted before defaults section.
+  globalConfig: ~
+  # globalConfig: |-
+  #   global
+  #     log stdout format raw local0
+  #     maxconn 4096
+
   ## Place any additional configuration section to add to the default config-haproxy.cfg
   # -- (string) Allows to place any additional configuration section to add to the default config-haproxy.cfg
   extraConfig: ~


### PR DESCRIPTION
Add support for HAProxy global section configuration via new haproxy.globalConfig parameter. This allows users to configure global HAProxy settings like logging and performance tuning without replacing the entire configuration.

The global section is inserted before the 'defaults' section in the generated haproxy.cfg when haproxy.customConfig is not set.

#### What this PR does / why we need it:
```
haproxy:
  extraConfig:
```
Not suitable for global non-configurations, as it is placed at the end of the config, and the order in the haproxy config is important.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
