### PR TITLE
[stable/redis-ha] Bump redis-exporter to v1.80.2

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.35.7
+version: 4.35.8
 appVersion: 8.2.2
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -744,7 +744,7 @@ exporter:
   # -- Exporter image
   image: quay.io/oliver006/redis_exporter
   # -- Exporter image tag
-  tag: v1.67.0
+  tag: v1.80.2
   # -- Exporter image pullPolicy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the redis-exporter sidecar container image from v1.67.0 to v1.80.2, bringing the chart up to date with the latest stable release of oliver006/redis_exporter.

The update includes:
- Support for Valkey 9.x, 8.x, 7.x metrics
- Redis search module metrics collection
- Sentinel configuration metrics
- Multiple bug fixes and improvements
- Updated to Go 1.25.6 for the exporter binary

This ensures users have access to the latest monitoring capabilities and security updates for their Redis HA deployments.

#### Which issue this PR fixes
fixes #381

#### Special notes for your reviewer:

The redis-exporter runs as a sidecar container in the Redis StatefulSet pods. The version jump from v1.67.0 to v1.80.2 is
backward compatible and should not introduce any breaking changes to existing deployments. The exporter connects to Redis on localhost and exposes metrics on port 9121 for Prometheus scraping.

No changes to the exporter configuration or API are required - this is purely a version bump to benefit from upstream
improvements.