### PR TITLE
[stable/redis-ha] Redis 8.2.4

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.35.7
-appVersion: 8.2.2
+version: 4.35.8
+appVersion: 8.2.3
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png
 maintainers:

--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - keyvalue
 - database
 version: 4.35.8
-appVersion: 8.2.3
+appVersion: 8.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png
 maintainers:

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -14,7 +14,7 @@ image:
   # -- Redis image repository
   repository: public.ecr.aws/docker/library/redis
   # -- Redis image tag
-  tag: 8.2.2-alpine
+  tag: 8.2.3-alpine
   # -- Redis image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -14,7 +14,7 @@ image:
   # -- Redis image repository
   repository: public.ecr.aws/docker/library/redis
   # -- Redis image tag
-  tag: 8.2.3-alpine
+  tag: 8.2.4-alpine
   # -- Redis image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps the default Redis image from 8.2.2-alpine to 8.2.3-alpine to fix CVE-2025-62507 a stack-based buffer overflow in the XACK/XDEL commands that may lead to remote code execution (CVSS 3.1: 8.8 HIGH).

- NVD: https://nvd.nist.gov/vuln/detail/CVE-2025-62507
- Advisory: https://github.com/redis/redis/security/advisories/GHSA-jhjx-x4cf-4vm8
- Fix: https://github.com/redis/redis/commit/5f83972188f6e5b1d6f1940218c650a9cbdf7741
- Release: https://github.com/redis/redis/releases/tag/8.2.3

#### Special notes for your reviewer:

Patch release only — no breaking changes. Redis 8.2.3 is backward-compatible with 8.2.2 (RDB files load cleanly).

