### PR TITLE
[stable/redis-ha] fix hostPath chown init container permissions

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.35.10
+version: 4.35.11
 appVersion: 8.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -129,11 +129,19 @@ spec:
 {{- if and .Values.hostPath.path .Values.hostPath.chown }}
       - name: hostpath-chown
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-        securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 10 }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        # hostPath ownership changes require root privileges.
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
         resources: {{ toYaml .Values.init.resources | nindent 10 }}
         command:
         - chown
-        - "{{ .Values.containerSecurityContext.runAsUser }}"
+        - "{{ .Values.containerSecurityContext.runAsUser }}:{{ default .Values.containerSecurityContext.runAsUser .Values.securityContext.fsGroup }}"
         - /data
         volumeMounts:
         - name: data


### PR DESCRIPTION
#### What this PR does / why we need it:
When `hostPath.chown=true`, `hostpath-chown` could fail with `chown: /data: Permission denied` because it inherited non-root container security settings. This PR makes that init container explicitly root-only for the ownership change step, keeps `allowPrivilegeEscalation: false`, and sets ownership as `uid:gid`.

#### Which issue this PR fixes
- fixes #396

#### Special notes for your reviewer:
- This is intentionally scoped to the `hostpath-chown` init container only; main Redis/Sentinel containers remain non-root.
- Chart version is bumped to include this fix.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)