### PR TITLE
[stable/redis-ha] Switch to standard labels

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.35.10
+version: 5.0.0
 appVersion: 8.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png

--- a/charts/redis-ha/templates/_helpers.tpl
+++ b/charts/redis-ha/templates/_helpers.tpl
@@ -42,10 +42,10 @@ labels.standard prints the standard Helm labels.
 The standard labels are frequently used in metadata.
 */ -}}
 {{- define "labels.standard" -}}
-app: {{ template "redis-ha.name" . }}
-heritage: {{ .Release.Service | quote }}
-release: {{ .Release.Name | quote }}
-chart: {{ template "chartref" . }}
+app.kubernetes.io/name: {{ template "redis-ha.name" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+helm.sh/chart: {{ template "chartref" . }}
 {{- end -}}
 
 {{- /*

--- a/charts/redis-ha/templates/redis-ha-announce-service.yaml
+++ b/charts/redis-ha/templates/redis-ha-announce-service.yaml
@@ -58,7 +58,7 @@ spec:
     targetPort: {{ $root.Values.exporter.portName }}
   {{- end }}
   selector:
-    release: {{ $root.Release.Name }}
-    app: {{ include "redis-ha.name" $root }}
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
+    app.kubernetes.io/name: {{ include "redis-ha.name" $root }}
     "statefulset.kubernetes.io/pod-name": {{ $fullName }}-server-{{ $i }}
 {{- end }}

--- a/charts/redis-ha/templates/redis-ha-configmap.yaml
+++ b/charts/redis-ha/templates/redis-ha-configmap.yaml
@@ -4,10 +4,10 @@ metadata:
   name: {{ template "redis-ha.fullname" . }}-configmap
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app: {{ template "redis-ha.fullname" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ template "redis-ha.fullname" . }}
     {{- range $key, $value := .Values.configmap.labels }}
     {{ $key }}: {{ $value | toString }}
     {{- end }}

--- a/charts/redis-ha/templates/redis-ha-health-configmap.yaml
+++ b/charts/redis-ha/templates/redis-ha-health-configmap.yaml
@@ -4,10 +4,10 @@ metadata:
   name: {{ template "redis-ha.fullname" . }}-health-configmap
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app: {{ template "redis-ha.fullname" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ template "redis-ha.fullname" . }}
     {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/redis-ha/templates/redis-ha-network-policy.yaml
+++ b/charts/redis-ha/templates/redis-ha-network-policy.yaml
@@ -19,8 +19,8 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      release: {{ .Release.Name }}
-      app: {{ template "redis-ha.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ template "redis-ha.name" . }}
   policyTypes:
     - Ingress
     - Egress
@@ -28,8 +28,8 @@ spec:
     - to:
       - podSelector: 
           matchLabels:
-            release: {{ .Release.Name }}
-            app: {{ template "redis-ha.name" . }}
+            app.kubernetes.io/instance: {{ .Release.Name }}
+            app.kubernetes.io/name: {{ template "redis-ha.name" . }}
       ports:
       {{- include "redis-ports" . | nindent 6 }}
 {{-  range $rule := .Values.networkPolicy.egressRules }}
@@ -42,16 +42,16 @@ spec:
     - from:
       - podSelector:
           matchLabels:
-            release: {{ .Release.Name }}
-            app: {{ template "redis-ha.name" . }}
+            app.kubernetes.io/instance: {{ .Release.Name }}
+            app.kubernetes.io/name: {{ template "redis-ha.name" . }}
       ports: 
       {{- include "redis-ports" . | nindent 6 }}
 {{- if .Values.haproxy.enabled }}
     - from:
         - podSelector:
             matchLabels:
-              release: {{ .Release.Name }}
-              app: {{ template "redis-ha.name" . }}-haproxy
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/name: {{ template "redis-ha.name" . }}-haproxy
       ports:
       {{- include "redis-ports" . | nindent 6 }}
 {{- end }}

--- a/charts/redis-ha/templates/redis-ha-pdb.yaml
+++ b/charts/redis-ha/templates/redis-ha-pdb.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      release: {{ .Release.Name }}
-      app: {{ template "redis-ha.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ template "redis-ha.name" . }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
 {{- end -}}

--- a/charts/redis-ha/templates/redis-ha-secret.yaml
+++ b/charts/redis-ha/templates/redis-ha-secret.yaml
@@ -11,10 +11,10 @@ metadata:
   name: {{ include "redis-ha.fullname" . }}-secret
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app: {{ template "redis-ha.fullname" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ template "redis-ha.fullname" . }}
     {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/redis-ha/templates/redis-ha-service.yaml
+++ b/charts/redis-ha/templates/redis-ha-service.yaml
@@ -53,5 +53,5 @@ spec:
     targetPort: {{ .Values.exporter.portName }}
 {{- end }}
   selector:
-    release: {{ .Release.Name }}
-    app: {{ template "redis-ha.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ template "redis-ha.name" . }}

--- a/charts/redis-ha/templates/redis-ha-serviceaccount.yaml
+++ b/charts/redis-ha/templates/redis-ha-serviceaccount.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "redis-ha.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app: {{ template "redis-ha.fullname" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ template "redis-ha.fullname" . }}
     {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/redis-ha/templates/redis-ha-servicemonitor.yaml
+++ b/charts/redis-ha/templates/redis-ha-servicemonitor.yaml
@@ -41,7 +41,7 @@ spec:
     - {{ .Release.Namespace | quote }}
   selector:
     matchLabels:
-      app: {{ template "redis-ha.name" . }}
-      release: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ template "redis-ha.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       exporter: enabled
 {{- end }}

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -18,8 +18,8 @@ metadata:
 spec:
   selector:
     matchLabels:
-      release: {{ .Release.Name }}
-      app: {{ template "redis-ha.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ template "redis-ha.name" . }}
   serviceName: {{ template "redis-ha.fullname" . }}
   replicas: {{ .Values.replicas }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
@@ -41,8 +41,8 @@ spec:
         prometheus.io/path: {{ .Values.exporter.scrapePath }}
       {{- end }}
       labels:
-        release: {{ .Release.Name }}
-        app: {{ template "redis-ha.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ template "redis-ha.name" . }}
         {{ template "redis-ha.fullname" . }}: replica
         {{- range $key, $value := .Values.labels }}
         {{ $key }}: {{ $value | toString }}
@@ -79,8 +79,8 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
-                  app: {{ template "redis-ha.name" . }}
-                  release: {{ .Release.Name }}
+                  app.kubernetes.io/name: {{ template "redis-ha.name" . }}
+                  app.kubernetes.io/instance: {{ .Release.Name }}
                   {{ template "redis-ha.fullname" . }}: replica
               topologyKey: kubernetes.io/hostname
     {{- else }}
@@ -89,8 +89,8 @@ spec:
               podAffinityTerm:
                 labelSelector:
                   matchLabels:
-                    app: {{ template "redis-ha.name" . }}
-                    release: {{ .Release.Name }}
+                    app.kubernetes.io/name: {{ template "redis-ha.name" . }}
+                    app.kubernetes.io/instance: {{ .Release.Name }}
                     {{ template "redis-ha.fullname" . }}: replica
                 topologyKey: kubernetes.io/hostname
     {{- end }}
@@ -102,8 +102,8 @@ spec:
         whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable | default "ScheduleAnyway" }}
         labelSelector:
           matchLabels:
-            app: {{ template "redis-ha.name" . }}
-            release: {{ .Release.Name }}
+            app.kubernetes.io/name: {{ template "redis-ha.name" . }}
+            app.kubernetes.io/instance: {{ .Release.Name }}
             {{ template "redis-ha.fullname" . }}: replica
       {{- end }}
       {{- if .Values.imagePullSecrets }}

--- a/charts/redis-ha/templates/redis-haproxy-deployment.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
-    component: haproxy
+    app.kubernetes.io/component: haproxy
     {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -25,16 +25,16 @@ spec:
   replicas: {{ .Values.haproxy.replicas }}
   selector:
     matchLabels:
-      app: {{ template "redis-ha.name" . }}-haproxy
-      release: {{ .Release.Name }}
-      component: haproxy
+      app.kubernetes.io/name: {{ template "redis-ha.name" . }}-haproxy
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: haproxy
   template:
     metadata:
       name: {{ template "redis-ha.fullname" . }}-haproxy
       labels:
-        app: {{ template "redis-ha.name" . }}-haproxy
-        release: {{ .Release.Name }}
-        component: haproxy
+        app.kubernetes.io/name: {{ template "redis-ha.name" . }}-haproxy
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: haproxy
         {{- range $key, $value := .Values.haproxy.labels }}
         {{ $key }}: {{ $value | toString }}
         {{- end }}
@@ -78,9 +78,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
-                  app: {{ template "redis-ha.name" . }}-haproxy
-                  release: {{ .Release.Name }}
-                  component: haproxy
+                  app.kubernetes.io/name: {{ template "redis-ha.name" . }}-haproxy
+                  app.kubernetes.io/instance: {{ .Release.Name }}
+                  app.kubernetes.io/component: haproxy
               topologyKey: kubernetes.io/hostname
     {{- else }}
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -88,9 +88,9 @@ spec:
               podAffinityTerm:
                 labelSelector:
                   matchLabels:
-                    app: {{ template "redis-ha.name" . }}-haproxy
-                    release: {{ .Release.Name }}
-                    component: haproxy
+                    app.kubernetes.io/name: {{ template "redis-ha.name" . }}-haproxy
+                    app.kubernetes.io/instance: {{ .Release.Name }}
+                    app.kubernetes.io/component: haproxy
                 topologyKey: kubernetes.io/hostname
     {{- end }}
     {{- end }}
@@ -101,9 +101,9 @@ spec:
         whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable | default "ScheduleAnyway" }}
         labelSelector:
           matchLabels:
-            app: {{ template "redis-ha.name" . }}-haproxy
-            release: {{ .Release.Name }}
-            component: haproxy
+            app.kubernetes.io/name: {{ template "redis-ha.name" . }}-haproxy
+            app.kubernetes.io/instance: {{ .Release.Name }}
+            app.kubernetes.io/component: haproxy
       {{- end }}
       initContainers:
       - name: config-init

--- a/charts/redis-ha/templates/redis-haproxy-network-policy.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-network-policy.yaml
@@ -19,9 +19,9 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      release: {{ .Release.Name }}
-      app: {{ template "redis-ha.name" . }}-haproxy
-      component: haproxy
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ template "redis-ha.name" . }}-haproxy
+      app.kubernetes.io/component: haproxy
   policyTypes:
     - Ingress
     - Egress
@@ -29,8 +29,8 @@ spec:
     - to:
         - podSelector:
             matchLabels:
-              release: {{ .Release.Name }}
-              app: {{ template "redis-ha.name" . }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/name: {{ template "redis-ha.name" . }}
       ports:
       {{- include "redis-ports" . | nindent 6 }}
     - to:
@@ -50,8 +50,8 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              release: {{ .Release.Name }}
-              app: {{ template "redis-ha.name" . }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/name: {{ template "redis-ha.name" . }}
       ports:
       {{- include "redis-ports" . | nindent 8 }}
     {{-  range $rule := .Values.haproxy.networkPolicy.ingressRules }}

--- a/charts/redis-ha/templates/redis-haproxy-pdb.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-pdb.yaml
@@ -12,8 +12,8 @@ metadata:
 spec:
   selector:
     matchLabels:
-      release: {{ .Release.Name }}
-      app: {{ template "redis-ha.name" . }}-haproxy
-      component: haproxy
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ template "redis-ha.name" . }}-haproxy
+      app.kubernetes.io/component: haproxy
 {{ toYaml .Values.haproxy.podDisruptionBudget | indent 2 }}
 {{- end -}}

--- a/charts/redis-ha/templates/redis-haproxy-role.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-role.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
-    component: haproxy
+    app.kubernetes.io/component: haproxy
     {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/redis-ha/templates/redis-haproxy-rolebinding.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-rolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
-    component: haproxy
+    app.kubernetes.io/component: haproxy
     {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/redis-ha/templates/redis-haproxy-service.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-service.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
-    component: haproxy
+    app.kubernetes.io/component: haproxy
 {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
 {{- end }}
@@ -61,6 +61,6 @@ spec:
     targetPort: {{ .name }}
 {{- end }}
   selector:
-    release: {{ .Release.Name }}
-    app: {{ template "redis-ha.name" . }}-haproxy
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ template "redis-ha.name" . }}-haproxy
 {{- end }}

--- a/charts/redis-ha/templates/redis-haproxy-serviceaccount.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-serviceaccount.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "redis-ha.serviceAccountName" . }}-haproxy
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app: {{ template "redis-ha.fullname" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ template "redis-ha.fullname" . }}
     {{- range $key, $value := .Values.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/redis-ha/templates/redis-haproxy-servicemonitor.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-servicemonitor.yaml
@@ -33,7 +33,7 @@ spec:
     - {{ .Release.Namespace | quote }}
   selector:
     matchLabels:
-      app: {{ template "redis-ha.name" . }}
-      release: {{ .Release.Name }}
-      component: haproxy
+      app.kubernetes.io/name: {{ template "redis-ha.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: haproxy
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Update label keys in `redis-ha` chart to follow common conventions:

- https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
- https://helm.sh/docs/chart_best_practices/labels/

`grafana-agent`, for example, already follows those.

#### Special notes for your reviewer:

Kept the same label order everywhere. Followed [Helm's best practices](https://helm.sh/docs/chart_best_practices/labels/#standard-labels) to decide on the new label names:

| Before | After |
| --- | --- |
| app | app.kubernetes.io/name |
| heritage | app.kubernetes.io/managed-by |
| release | app.kubernetes.io/instance |
| chart | helm.sh/chart |
| component | app.kubernetes.io/component |

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
