### PR TITLE
feat(redis-ha): add headless service and dual-stack support for HAProxy

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.35.10
+version: 4.36.0
 appVersion: 8.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png

--- a/charts/redis-ha/templates/redis-haproxy-service.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-service.yaml
@@ -19,6 +19,15 @@ metadata:
   {{- end }}
 spec:
   type: {{ default "ClusterIP" .Values.haproxy.service.type }}
+  {{- if .Values.haproxy.service.clusterIP }}
+  clusterIP: {{ .Values.haproxy.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.haproxy.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.haproxy.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.haproxy.service.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.haproxy.service.ipFamilies | nindent 2 }}
+  {{- end }}
   {{- if and (eq .Values.haproxy.service.type "LoadBalancer") .Values.haproxy.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.haproxy.service.loadBalancerIP }}
   {{- end }}

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -182,6 +182,8 @@ haproxy:
   service:
     # -- HAProxy service type "ClusterIP", "LoadBalancer" or "NodePort"
     type: ClusterIP
+    # -- HAProxy service clusterIP. Set to "None" to create a headless service.
+    clusterIP: ""
     # -- (int) HAProxy service nodePort value (haproxy.service.type must be NodePort)
     nodePort: ~
     # -- HAProxy service loadbalancer IP
@@ -197,6 +199,10 @@ haproxy:
 
     # -- List of CIDR's allowed to connect to LoadBalancer
     loadBalancerSourceRanges: []
+    # -- HAProxy service IP family policy for dual-stack clusters
+    ipFamilyPolicy: ""
+    # -- HAProxy service IP families (e.g. ["IPv4", "IPv6"] for dual-stack)
+    ipFamilies: []
 
   # -- HAProxy serviceAccountName
   serviceAccountName: redis-sa


### PR DESCRIPTION
## Summary

This PR adds two networking enhancements to the redis-ha HAProxy service:

- **Headless service support** (#388): New `haproxy.service.clusterIP` value lets users set `clusterIP: None` to bypass the service VIP and route directly to pod IPs. Defaults to `""` (standard ClusterIP behavior, no change for existing users).
- **Dual-stack / IP family support** (#366): New `haproxy.service.ipFamilyPolicy` and `haproxy.service.ipFamilies` values expose the Kubernetes Service dual-stack fields. This allows clusters running IPv4+IPv6 to configure the HAProxy service accordingly (e.g. `ipFamilyPolicy: PreferDualStack`, `ipFamilies: ["IPv4", "IPv6"]`). Both default to empty, preserving existing behavior.

The deprecated `loadBalancerIP` field is intentionally kept for backward compatibility.

## Changes

- `charts/redis-ha/values.yaml`: Added `clusterIP: ""`, `ipFamilyPolicy: ""`, and `ipFamilies: []` under `haproxy.service`.
- `charts/redis-ha/templates/redis-haproxy-service.yaml`: Added conditional rendering of `clusterIP`, `ipFamilyPolicy`, and `ipFamilies` in the Service `spec`, inserted between the `type` field and the existing `loadBalancerIP` block.

## Test plan

- [ ] Render chart with default values — confirm no change in rendered Service spec
- [ ] Render with `haproxy.service.clusterIP: None` — confirm `clusterIP: None` appears in Service spec
- [ ] Render with `haproxy.service.ipFamilyPolicy: PreferDualStack` and `haproxy.service.ipFamilies: [IPv4, IPv6]` — confirm both fields appear correctly in Service spec
- [ ] Confirm existing `LoadBalancer` / `NodePort` behavior is unaffected

Closes #388
Closes #366