### PR TITLE
fix(redis-ha): split-brain script race condition and silent quorum failure

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.36.2
+version: 4.37.0
 appVersion: 8.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png

--- a/charts/redis-ha/templates/_configs.tpl
+++ b/charts/redis-ha/templates/_configs.tpl
@@ -501,6 +501,9 @@
         identify_announce_ip
     done
 
+    QUORUM_FAIL_COUNT=0
+    MAX_QUORUM_FAILURES=${MAX_QUORUM_FAILURES:-5}
+
     trap "exit 0" TERM
     while true; do
         sleep {{ .Values.splitBrainDetection.interval }}
@@ -509,6 +512,7 @@
         identify_master
 
         if [ "$MASTER" = "$ANNOUNCE_IP" ]; then
+            QUORUM_FAIL_COUNT=0
             redis_role
             if [ "$ROLE" != "master" ]; then
                 echo "waiting for redis to become master"
@@ -522,17 +526,34 @@
                 fi
             fi
         elif [ "${MASTER}" ]; then
+            QUORUM_FAIL_COUNT=0
             identify_redis_master
             if [ "$REDIS_MASTER" != "$MASTER" ]; then
                 echo "Redis master and local master are not the same. waiting."
                 sleep {{ .Values.splitBrainDetection.retryInterval }}
                 identify_master
-                identify_redis_master
-                echo "Redis master is ${MASTER}, expected master is ${REDIS_MASTER}. No need to reinitialize."
-                if [ "${REDIS_MASTER}" != "${MASTER}" ]; then
-                    echo "Redis master is ${MASTER}, expected master is ${REDIS_MASTER}, reinitializing"
-                    reinit
+                if [ "$MASTER" = "$ANNOUNCE_IP" ]; then
+                    echo "This pod became master during wait, skipping reinit"
+                else
+                    identify_redis_master
+                    echo "Redis master is ${MASTER}, expected master is ${REDIS_MASTER}. No need to reinitialize."
+                    if [ "${REDIS_MASTER}" != "${MASTER}" ]; then
+                        echo "Redis master is ${MASTER}, expected master is ${REDIS_MASTER}, reinitializing"
+                        reinit
+                    fi
                 fi
+            fi
+        else
+            QUORUM_FAIL_COUNT=$((QUORUM_FAIL_COUNT + 1))
+            echo "WARNING: Sentinel returned no master (quorum may be broken). Failure count: $QUORUM_FAIL_COUNT/$MAX_QUORUM_FAILURES"
+            if [ "$QUORUM_FAIL_COUNT" -ge "$MAX_QUORUM_FAILURES" ]; then
+                echo "ERROR: Quorum broken for $MAX_QUORUM_FAILURES consecutive checks. Attempting sentinel reset..."
+                if [ "$SENTINEL_PORT" -eq 0 ]; then
+                    redis-cli -h "${SERVICE}" -p "${SENTINEL_TLS_PORT}" {{ if .Values.sentinel.auth }} -a "${SENTINELAUTH}" --no-auth-warning{{ end }} --tls --cacert /tls-certs/{{ .Values.tls.caCertFile }} {{ if ne (default "yes" .Values.sentinel.authClients) "no"}} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}{{ end }} sentinel reset "${MASTER_GROUP}" || true
+                else
+                    redis-cli -h "${SERVICE}" -p "${SENTINEL_PORT}" {{ if .Values.sentinel.auth }} -a "${SENTINELAUTH}" --no-auth-warning{{ end }} sentinel reset "${MASTER_GROUP}" || true
+                fi
+                QUORUM_FAIL_COUNT=0
             fi
         fi
     done


### PR DESCRIPTION
## Summary

Fixes two bugs in the `fix-split-brain.sh` template in `charts/redis-ha/templates/_configs.tpl`.

### Fix 1 — Race condition causes unnecessary master shutdown (#383)

**Problem:** In the `elif [ "${MASTER}" ]` branch, when the script detects a mismatch between the Redis master and the local master, it sleeps and then re-checks. However, if this pod was elected master *during that sleep*, `identify_redis_master()` returns an empty string (because masters have no `master_host` field in `redis info`). The comparison `"" != "<ip>"` evaluates to true, incorrectly triggering `reinit` and shutting down a healthy master.

**Fix:** After the sleep and `identify_master`, check whether `MASTER == ANNOUNCE_IP` (i.e. this pod is now the master). If so, skip the reinit entirely with a clear log message.

### Fix 2 — No-master / quorum-broken case silently ignored (#398)

**Problem:** When Sentinel has no quorum and returns no master, `identify_master` sets `MASTER` to empty. Neither the `if` nor the `elif` branch fires, so the script loops silently with no action taken and no operator visibility.

**Fix:** Add an `else` branch that increments a `QUORUM_FAIL_COUNT` counter and logs a warning on every occurrence. After `MAX_QUORUM_FAILURES` consecutive failures (default: 5, overridable via env var), the script issues a `sentinel reset` command to attempt recovery, then resets the counter.

## Changes

- `charts/redis-ha/templates/_configs.tpl`: Updated the main split-brain detection loop in the `fix-split-brain.sh` template with both fixes above. Counter variables (`QUORUM_FAIL_COUNT`, `MAX_QUORUM_FAILURES`) are initialised before the trap/loop so they survive across iterations.

## Test plan

- [x] Deploy redis-ha with split-brain detection enabled
- [x] Simulate a scenario where a replica pod is elected master during the split-brain retry sleep — confirm the pod does **not** reinitialise itself (#383)
- [x] Simulate a Sentinel quorum loss (e.g. kill majority of sentinels) — confirm WARNING messages appear each interval and that `sentinel reset` is attempted after 5 consecutive failures (#398)
- [x] Confirm `MAX_QUORUM_FAILURES` env var overrides the default threshold
- [x] Confirm normal split-brain detection and reinit still works for genuine mismatches

Closes #383
Closes #398