### PR TITLE
fix(redis-ha): update HAProxy image to 3.0.18-alpine (CVE-2025-15467)

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.35.10
+version: 4.35.11
 appVersion: 8.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png

--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.35.11
+version: 4.36.1
 appVersion: 8.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -137,7 +137,7 @@ haproxy:
     # -- HAProxy Image Repository
     repository: public.ecr.aws/docker/library/haproxy
     # -- HAProxy Image Tag
-    tag: 3.0.18-alpine
+    tag: 3.3.10-alpine
     # -- HAProxy Image PullPolicy
     pullPolicy: IfNotPresent
 

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -137,7 +137,7 @@ haproxy:
     # -- HAProxy Image Repository
     repository: public.ecr.aws/docker/library/haproxy
     # -- HAProxy Image Tag
-    tag: 3.0.8-alpine
+    tag: 3.0.18-alpine
     # -- HAProxy Image PullPolicy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

Fixes #392.

The HAProxy image pinned in `charts/redis-ha/values.yaml` (`haproxy:3.0.8-alpine`) ships with a vulnerable version of libssl that is affected by **CVE-2025-15467** (libssl memory-corruption vulnerability). The Alpine security tracker lists `libssl 3.5.5-r0` as the first patched version, which is included in `haproxy:3.0.18-alpine`.

- Updates `haproxy.image.tag` from `3.0.8-alpine` → `3.0.18-alpine`
- Stays on the same minor track (`3.0.x`) to maintain API/behavioural compatibility
- Bumps chart version `4.35.10` → `4.35.11`

## Test plan

- [ ] Verify `haproxy:3.0.18-alpine` pulls successfully from `public.ecr.aws/docker/library/haproxy`
- [ ] Deploy redis-ha with `haproxy.enabled=true` and confirm HAProxy pods come up healthy
- [ ] Confirm CVE-2025-15467 is no longer flagged by your container scanner against the new image