### PR TITLE
fix(redis-ha): hostPath chown init container must run as root

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.36.1
+version: 4.36.2
 appVersion: 8.2.4
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -129,11 +129,13 @@ spec:
 {{- if and .Values.hostPath.path .Values.hostPath.chown }}
       - name: hostpath-chown
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-        securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 10 }}
+        securityContext:
+          runAsUser: 0
+          runAsNonRoot: false
         resources: {{ toYaml .Values.init.resources | nindent 10 }}
         command:
         - chown
-        - "{{ .Values.containerSecurityContext.runAsUser }}"
+        - "{{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}"
         - /data
         volumeMounts:
         - name: data


### PR DESCRIPTION
## Problem

Closes #396

When `hostPath.chown=true`, the `hostpath-chown` init container was inheriting the pod's `containerSecurityContext` via the `compatibility.renderSecurityContext` helper. This meant it ran with `runAsNonRoot: true` and `runAsUser: 1000`, causing `chown` to fail with "Permission denied" — you cannot change file ownership as a non-root user on a host-mounted directory.

Additionally, the chown command only set the user portion of the ownership (`runAsUser`), leaving the group ownership unchanged and not matching the pod's `fsGroup`.

## Fix

1. **Override securityContext for this init container only** — set `runAsUser: 0` and `runAsNonRoot: false` explicitly, so the `hostpath-chown` init container runs as root (required to `chown` a host-mounted path). All other containers are unaffected and continue to use the non-root `containerSecurityContext`.

2. **Set `uid:gid` ownership** — change the chown argument from `"{{ .Values.containerSecurityContext.runAsUser }}"` to `"{{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}"` so both user and group ownership are set correctly, matching the pod-level `fsGroup` (default: 1000) used at runtime.

## Changes

`charts/redis-ha/templates/redis-ha-statefulset.yaml`

- Replace inherited `securityContext` with explicit `runAsUser: 0` / `runAsNonRoot: false` for the `hostpath-chown` init container
- Expand chown target from `uid` to `uid:gid`
