### PR TITLE
feat(valkey-ha): add Valkey HA chart as drop-in replacement for redis-ha

### DIFF
--- a/charts/valkey-ha/.helmignore
+++ b/charts/valkey-ha/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+ci/
+*.gotmpl

--- a/charts/valkey-ha/Chart.yaml
+++ b/charts/valkey-ha/Chart.yaml
@@ -18,3 +18,13 @@ sources:
 - https://github.com/valkey-io/valkey
 - https://github.com/DandyDeveloper/charts/blob/master/charts/valkey-ha
 - https://github.com/oliver006/redis_exporter
+annotations:
+  # Valkey is BSD-3-Clause licensed — the permissive, open-source alternative to Redis
+  artifacthub.io/license: BSD-3-Clause
+  artifacthub.io/images: |
+    - name: valkey
+      image: valkey/valkey:8.1.8-alpine
+    - name: redis-exporter
+      image: quay.io/oliver006/redis_exporter:v1.80.2
+    - name: haproxy
+      image: public.ecr.aws/docker/library/haproxy:3.0.8-alpine

--- a/charts/valkey-ha/Chart.yaml
+++ b/charts/valkey-ha/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: valkey-ha
+home: https://valkey.io/
+keywords:
+- valkey
+- redis
+- keyvalue
+- database
+version: 1.0.0
+appVersion: 8.1.8
+description: This Helm chart provides a highly available Valkey implementation (a drop-in replacement for Redis) with a master/slave configuration and uses Sentinel sidecars for failover management
+icon: https://raw.githubusercontent.com/valkey-io/valkey-io.github.io/main/static/img/Valkey-logo-white-bg.svg
+maintainers:
+- email: aaron.layfield@gmail.com
+  name: dandydeveloper
+sources:
+- https://valkey.io/download/
+- https://github.com/valkey-io/valkey
+- https://github.com/DandyDeveloper/charts/blob/master/charts/valkey-ha
+- https://github.com/oliver006/redis_exporter

--- a/charts/valkey-ha/README.md
+++ b/charts/valkey-ha/README.md
@@ -18,7 +18,7 @@ By default this chart install 3 pods total:
 
 ## Introduction
 
-This chart bootstraps a [Valkey](https://valkey.io/) highly available master/slave statefulset in a [Kubernetes](http://kubernetes.io) cluster using the Helm package manager.
+This chart bootstraps a [Valkey](https://valkey.io/) highly available primary/replica statefulset in a [Kubernetes](http://kubernetes.io) cluster using the Helm package manager.
 
 ## Prerequisites
 
@@ -43,7 +43,7 @@ helm repo add dandydev https://dandydeveloper.github.io/charts
 helm install dandydev/valkey-ha
 ```
 
-The command deploys Redis on the Kubernetes cluster in the default configuration. By default this chart install one master pod containing redis master container and sentinel container along with 2 redis slave pods each containing their own sentinel sidecars. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The command deploys Valkey on the Kubernetes cluster in the default configuration. By default this chart install one primary pod containing a valkey master container and sentinel container along with 2 valkey replica pods each containing their own sentinel sidecars. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
@@ -59,7 +59,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following table lists the configurable parameters of the Redis chart and their default values.
+The following table lists the configurable parameters of the Valkey chart and their default values.
 
 ### General parameters
 
@@ -114,12 +114,14 @@ The following table lists the configurable parameters of the Redis chart and the
 | `rbac.create` | Create and use RBAC resources | bool | `true` |
 | `redis.annotations` | Annotations for the redis statefulset | object | `{}` |
 | `redis.authClients` | It is possible to disable client side certificates authentication when "authClients" is set to "no" | string | `""` |
-| `redis.config` | Any valid redis config options in this section will be applied to each server, For multi-value configs use list instead of string (for example loadmodule) (see below) | object | see values.yaml |
-| `redis.config.maxmemory` | Max memory to use for each redis instance. Default is unlimited. | string | `"0"` |
-| `redis.config.maxmemory-policy` | Max memory policy to use for each redis instance. Default is volatile-lru. | string | `"volatile-lru"` |
+| `redis.config` | Any valid valkey/redis config options in this section will be applied to each server, For multi-value configs use list instead of string (for example loadmodule) (see below) | object | see values.yaml |
+| `redis.config.dual-channel-replication-enabled` | (string) Valkey 8.0+ dual-channel replication. Streams the RDB and the replication backlog on separate channels to speed up full syncs. Set to "yes" to enable. | string | `"no"` |
+| `redis.config.io-threads` | (int) Number of I/O threads. Valkey 8.0 reworked I/O threading for much higher throughput on multi-core nodes. Default is 1 (disabled); raise to roughly the number of cores allocated to the pod to benefit from it. | int | `1` |
+| `redis.config.maxmemory` | Max memory to use for each valkey instance. Default is unlimited. | string | `"0"` |
+| `redis.config.maxmemory-policy` | Max memory policy to use for each valkey instance. Default is volatile-lru. | string | `"volatile-lru"` |
 | `redis.config.min-replicas-max-lag` | Value in seconds | int | `5` |
-| `redis.config.repl-diskless-sync` | When enabled, directly sends the RDB over the wire to slaves, without using the disk as intermediate storage. Default is false. | string | `"yes"` |
-| `redis.config.save` | Please note that local (on-disk) RDBs will still be created when re-syncing with a new slave. The only way to prevent this is to enable diskless replication. | string | `"900 1"` |
+| `redis.config.repl-diskless-sync` | When enabled, directly sends the RDB over the wire to replicas, without using the disk as intermediate storage. Default is false. | string | `"yes"` |
+| `redis.config.save` | Please note that local (on-disk) RDBs will still be created when re-syncing with a new replica. The only way to prevent this is to enable diskless replication. | string | `"900 1"` |
 | `redis.customArgs` | Allows overriding the redis container arguments | list | `[]` |
 | `redis.customCommand` | Allows overriding the redis container command | list | `[]` |
 | `redis.customConfig` | Allows for custom redis.conf files to be applied. If this is used then `redis.config` is ignored | string | `nil` |
@@ -413,6 +415,18 @@ Sentinel options supported must be in the the `sentinel <option> <master-group-n
 ```
 
 If more control is needed from either the redis or sentinel config then an entire config can be defined under `redis.customConfig` or `sentinel.customConfig`. Please note that these values will override any configuration options under their respective section. For example, if you define `sentinel.customConfig` then the `sentinel.config` is ignored.
+
+## Valkey-native options
+
+This chart ships the official [`valkey/valkey`](https://hub.docker.com/r/valkey/valkey) image and exposes a few [Valkey 8.x](https://valkey.io/blog/valkey-8-0-0-rc1/) features under `redis.config`:
+
+- **Dual-channel replication** (`dual-channel-replication-enabled`): streams the RDB and the replication backlog on separate channels to speed up full syncs. Disabled by default.
+- **I/O threads** (`io-threads`): Valkey 8.0 reworked I/O threading for substantially higher throughput on multi-core nodes. Defaults to `1` (disabled); raise it towards the number of cores allocated to the pod.
+- **Availability zone** (`availability-zone`): an AZ hint reported via `INFO` and used by AZ-aware clients (e.g. valkey-glide) for locality-aware reads. A single value applies to every replica, so set it only when pods are pinned to one zone (otherwise inject a per-pod value via `redis.customConfig`).
+
+Replication is configured using Valkey's canonical `replicaof` / `replica-announce-*` directives.
+
+To use the [Valkey module bundle](https://hub.docker.com/r/valkey/valkey-bundle) (JSON, search, bloom, …) set `image.repository: valkey/valkey-bundle` and load the modules via the `redis.config.loadmodule` list.
 
 ## Host Kernel Settings
 

--- a/charts/valkey-ha/README.md
+++ b/charts/valkey-ha/README.md
@@ -1,0 +1,502 @@
+# Valkey
+
+[Valkey](https://valkey.io/) is an open source (BSD), high-performance key/value datastore and a drop-in replacement for Redis. It supports strings, hashes, lists, sets, sorted sets, bitmaps, hyperloglogs and more, speaking the same RESP protocol so existing Redis clients and tooling work unmodified.
+
+This chart is a Valkey-flavoured copy of the `redis-ha` chart. It keeps the same `values.yaml` interface (the `redis.*` / `sentinel.*` keys are preserved) so it can be used as a drop-in replacement, while shipping the official [`valkey/valkey`](https://hub.docker.com/r/valkey/valkey) image and the native `valkey-server`/`valkey-sentinel`/`valkey-cli` binaries.
+
+## TL;DR
+
+```bash
+helm repo add dandydev https://dandydeveloper.github.io/charts
+helm install dandydev/valkey-ha
+```
+
+By default this chart install 3 pods total:
+
+* one pod containing a valkey master and sentinel container (optional prometheus metrics exporter sidecar available)
+* two pods each containing a valkey slave and sentinel containers (optional prometheus metrics exporter sidecars available)
+
+## Introduction
+
+This chart bootstraps a [Valkey](https://valkey.io/) highly available master/slave statefulset in a [Kubernetes](http://kubernetes.io) cluster using the Helm package manager.
+
+## Prerequisites
+
+* Kubernetes 1.8+ with Beta APIs enabled
+* PV provisioner support in the underlying infrastructure
+* Helm v3+
+
+## Upgrading the Chart
+
+Please note that there have been a number of changes simplifying the redis management strategy (for better failover and elections) in the 3.x version of this chart. These changes allow the use of official [redis](https://hub.docker.com/_/redis/) images that do not require special RBAC or ServiceAccount roles. As a result when upgrading from version >=2.0.1 to >=3.0.0 of this chart, `Role`, `RoleBinding`, and `ServiceAccount` resources should be deleted manually.
+
+### Upgrading the chart from 3.x to 4.x
+
+Starting from version `4.x` HAProxy sidecar prometheus-exporter removed and replaced by the embedded [HAProxy metrics endpoint](https://github.com/haproxy/haproxy/tree/master/contrib/prometheus-exporter), as a result when upgrading from version 3.x to 4.x section `haproxy.exporter` should be removed and the `haproxy.metrics` need to be configured for fit your needs.
+
+## Installing the Chart
+
+To install the chart
+
+```bash
+helm repo add dandydev https://dandydeveloper.github.io/charts
+helm install dandydev/valkey-ha
+```
+
+The command deploys Redis on the Kubernetes cluster in the default configuration. By default this chart install one master pod containing redis master container and sentinel container along with 2 redis slave pods each containing their own sentinel sidecars. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the deployment:
+
+```bash
+helm delete <chart-name>
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Redis chart and their default values.
+
+### General parameters
+
+| Parameter | Description | Type | Default |
+|-----|------|---------|-------------|
+| `additionalAffinities` | Additional affinities to add to the Redis server pods. # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity | object | `{}` |
+| `affinity` | Override all other affinity settings for the Redis server pods with a string. | string | `""` |
+| `auth` | Configures redis with AUTH (requirepass & masterauth conf params) | bool | `false` |
+| `authKey` | Defines the key holding the redis password in existing secret. | string | `"auth"` |
+| `authSecretAnnotations` | Annotations for auth secret | object | `{}` |
+| `configmap.labels` | Custom labels for the redis configmap | object | `{}` |
+| `configmapTest.image` | Image for valkey-ha-configmap-test hook | object | `{"repository":"koalaman/shellcheck","tag":"v0.10.0"}` |
+| `configmapTest.image.repository` | Repository of the configmap shellcheck test image. | string | `"koalaman/shellcheck"` |
+| `configmapTest.image.tag` | Tag of the configmap shellcheck test image. | string | `"v0.10.0"` |
+| `configmapTest.resources` | Resources for the ConfigMap test pod | object | `{}` |
+| `containerSecurityContext` | Security context to be added to the Redis containers. | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` |
+| `emptyDir` | Configuration of `emptyDir`, used only if persistentVolume is disabled and no hostPath specified | object | `{}` |
+| `existingSecret` | An existing secret containing a key defined by `authKey` that configures `requirepass` and `masterauth` in the conf parameters (Requires `auth: enabled`, cannot be used in conjunction with `.Values.redisPassword`) | string | `nil` |
+| `extraContainers` | Extra containers to include in StatefulSet | list | `[]` |
+| `extraInitContainers` | Extra init containers to include in StatefulSet | list | `[]` |
+| `extraLabels` | Labels added here are applied to all created resources | object | `{}` |
+| `extraVolumes` | Extra volumes to include in StatefulSet | list | `[]` |
+| `fullnameOverride` | Full name of the Valkey HA Resources | string | `""` |
+| `global.compatibility` | Openshift compatibility options | object | `{"openshift":{"adaptSecurityContext":"auto"}}` |
+| `global.priorityClassName` | Default priority class for all components | string | `""` |
+| `hardAntiAffinity` | Whether the Redis server pods should be forced to run on separate nodes. # This is accomplished by setting their AntiAffinity with requiredDuringSchedulingIgnoredDuringExecution as opposed to preferred. # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature | bool | `true` |
+| `hostPath.chown` | if chown is true, an init-container with root permissions is launched to change the owner of the hostPath folder to the user defined in the security context | bool | `true` |
+| `hostPath.path` | Use this path on the host for data storage. path is evaluated as template so placeholders are replaced | string | `""` |
+| `image.pullPolicy` | Valkey image pull policy | string | `"IfNotPresent"` |
+| `image.repository` | Valkey image repository | string | `"valkey/valkey"` |
+| `image.tag` | Valkey image tag | string | `"8.1.8-alpine"` |
+| `imagePullSecrets` | Reference to one or more secrets to be used when pulling redis images | list | `[]` |
+| `init.resources` | Extra init resources | object | `{}` |
+| `labels` | Custom labels for the redis pod | object | `{}` |
+| `nameOverride` | Name override for Valkey HA resources | string | `""` |
+| `networkPolicy.annotations` | Annotations for NetworkPolicy | object | `{}` |
+| `networkPolicy.egressRules` | user can define egress rules too, uses the same structure as ingressRules | list | `[{"ports":[{"port":53,"protocol":"UDP"},{"port":53,"protocol":"TCP"}],"selectors":[{"namespaceSelector":{}},{"ipBlock":{"cidr":"169.254.0.0/16"}}]}]` |
+| `networkPolicy.egressRules[0].selectors[0]` | Allow all destinations for DNS traffic | object | `{"namespaceSelector":{}}` |
+| `networkPolicy.enabled` | whether NetworkPolicy for Redis StatefulSets should be created. when enabled, inter-Redis connectivity is created | bool | `false` |
+| `networkPolicy.ingressRules` | User defined ingress rules that Redis should permit into. Uses the format defined in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors | list | `[]` |
+| `networkPolicy.labels` | Labels for NetworkPolicy | object | `{}` |
+| `nodeSelector` | Node labels for pod assignment | object | `{}` |
+| `persistentVolume.accessModes` | Persistent volume access modes | list | `["ReadWriteOnce"]` |
+| `persistentVolume.annotations` | Annotations for the volume | object | `{}` |
+| `persistentVolume.enabled` | Enable persistent volume | bool | `true` |
+| `persistentVolume.labels` | Labels for the volume | object | `{}` |
+| `persistentVolume.size` | Persistent volume size | string | `"10Gi"` |
+| `persistentVolume.storageClass` | valkey-ha data Persistent Volume Storage Class | string | `nil` |
+| `podDisruptionBudget` | Pod Disruption Budget rules | object | `{}` |
+| `podManagementPolicy` | The statefulset pod management policy | string | `"OrderedReady"` |
+| `priorityClassName` | Kubernetes priorityClass name for the valkey-ha-server pod | string | `""` |
+| `rbac.create` | Create and use RBAC resources | bool | `true` |
+| `redis.annotations` | Annotations for the redis statefulset | object | `{}` |
+| `redis.authClients` | It is possible to disable client side certificates authentication when "authClients" is set to "no" | string | `""` |
+| `redis.config` | Any valid redis config options in this section will be applied to each server, For multi-value configs use list instead of string (for example loadmodule) (see below) | object | see values.yaml |
+| `redis.config.maxmemory` | Max memory to use for each redis instance. Default is unlimited. | string | `"0"` |
+| `redis.config.maxmemory-policy` | Max memory policy to use for each redis instance. Default is volatile-lru. | string | `"volatile-lru"` |
+| `redis.config.min-replicas-max-lag` | Value in seconds | int | `5` |
+| `redis.config.repl-diskless-sync` | When enabled, directly sends the RDB over the wire to slaves, without using the disk as intermediate storage. Default is false. | string | `"yes"` |
+| `redis.config.save` | Please note that local (on-disk) RDBs will still be created when re-syncing with a new slave. The only way to prevent this is to enable diskless replication. | string | `"900 1"` |
+| `redis.customArgs` | Allows overriding the redis container arguments | list | `[]` |
+| `redis.customCommand` | Allows overriding the redis container command | list | `[]` |
+| `redis.customConfig` | Allows for custom redis.conf files to be applied. If this is used then `redis.config` is ignored | string | `nil` |
+| `redis.disableCommands` | Array with commands to disable | list | `["FLUSHDB","FLUSHALL"]` |
+| `redis.envFrom` | Load environment variables from ConfigMap/Secret | list | `[]` |
+| `redis.extraVolumeMounts` | additional volumeMounts for Redis container | list | `[]` |
+| `redis.lifecycle` | Container Lifecycle Hooks for redis container Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/ | object | see values.yaml |
+| `redis.livenessProbe` | Liveness probe parameters for redis container | object | `{"enabled":true,"failureThreshold":5,"initialDelaySeconds":30,"periodSeconds":15,"successThreshold":1,"timeoutSeconds":15}` |
+| `redis.livenessProbe.enabled` | Enable the Liveness Probe | bool | `true` |
+| `redis.livenessProbe.failureThreshold` | Failure threshold for liveness probe | int | `5` |
+| `redis.livenessProbe.initialDelaySeconds` | Initial delay in seconds for liveness probe | int | `30` |
+| `redis.livenessProbe.periodSeconds` | Period in seconds after which liveness probe will be repeated | int | `15` |
+| `redis.livenessProbe.successThreshold` | Success threshold for liveness probe | int | `1` |
+| `redis.livenessProbe.timeoutSeconds` | Timeout seconds for liveness probe | int | `15` |
+| `redis.masterGroupName` | Redis convention for naming the cluster group: must match `^[\\w-\\.]+$` and can be templated | string | `"mymaster"` |
+| `redis.minReadySeconds` | Configure the 'minReadySeconds' parameter to StatefulSet ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minreadyseconds | int | `0` |
+| `redis.podAnnotations` | Annotations to be added to the redis statefulset pods | object | `{}` |
+| `redis.port` | Port to access the redis service | int | `6379` |
+| `redis.readinessProbe` | Readiness probe parameters for redis container | object | `{"enabled":true,"failureThreshold":5,"initialDelaySeconds":30,"periodSeconds":15,"successThreshold":1,"timeoutSeconds":15}` |
+| `redis.readinessProbe.enabled` | Enable the Readiness Probe | bool | `true` |
+| `redis.readinessProbe.failureThreshold` | Failure threshold for readiness probe | int | `5` |
+| `redis.readinessProbe.initialDelaySeconds` | Initial delay in seconds for readiness probe | int | `30` |
+| `redis.readinessProbe.periodSeconds` | Period in seconds after which readiness probe will be repeated | int | `15` |
+| `redis.readinessProbe.successThreshold` | Success threshold for readiness probe | int | `1` |
+| `redis.readinessProbe.timeoutSeconds` | Timeout seconds for readiness probe | int | `15` |
+| `redis.resources` | CPU/Memory for master/slave nodes resource requests/limits | object | `{}` |
+| `redis.startupProbe` | Startup probe parameters for redis container | object | `{"enabled":true,"failureThreshold":5,"initialDelaySeconds":30,"periodSeconds":15,"successThreshold":1,"timeoutSeconds":15}` |
+| `redis.startupProbe.enabled` | Enable Startup Probe | bool | `true` |
+| `redis.startupProbe.failureThreshold` | Failure threshold for startup probe | int | `5` |
+| `redis.startupProbe.initialDelaySeconds` | Initial delay in seconds for startup probe | int | `30` |
+| `redis.startupProbe.periodSeconds` | Period in seconds after which startup probe will be repeated | int | `15` |
+| `redis.startupProbe.successThreshold` | Success threshold for startup probe | int | `1` |
+| `redis.startupProbe.timeoutSeconds` | Timeout seconds for startup probe | int | `15` |
+| `redis.terminationGracePeriodSeconds` | Increase terminationGracePeriodSeconds to allow writing large RDB snapshots. (k8s default is 30s) ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination-forced | int | `60` |
+| `redis.tlsPort` | TLS Port to access the redis service | int | `nil` |
+| `redis.tlsReplication` | Configures redis with tls-replication parameter, if true sets "tls-replication yes" in redis.conf | bool | `nil` |
+| `redis.updateStrategy` | Update strategy for Redis StatefulSet # ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies | object | `{"type":"RollingUpdate"}` |
+| `redisPassword` | A password that configures a `requirepass` and `masterauth` in the conf parameters (Requires `auth: enabled`) | string | `nil` |
+| `replicas` | Number of redis master/slave | int | `3` |
+| `restore.existingSecret` | Set existingSecret to true to use secret specified in existingSecret above | bool | `false` |
+| `restore.redis.source` |  | string | `""` |
+| `restore.s3.access_key` | Restore init container - AWS AWS_ACCESS_KEY_ID to access restore.s3.source | string | `""` |
+| `restore.s3.region` | Restore init container - AWS AWS_REGION to access restore.s3.source | string | `""` |
+| `restore.s3.secret_key` | Restore init container - AWS AWS_SECRET_ACCESS_KEY to access restore.s3.source | string | `""` |
+| `restore.s3.source` | Restore init container - AWS S3 location of dump - i.e. s3://bucket/dump.rdb or false | string | `""` |
+| `restore.ssh.key` | Restore init container - SSH private key to scp restore.ssh.source to init container. Key should be in one line separated with \n. i.e. `-----BEGIN RSA PRIVATE KEY-----\n...\n...\n-----END RSA PRIVATE KEY-----` | string | `""` |
+| `restore.ssh.source` | Restore init container - SSH scp location of dump - i.e. user@server:/path/dump.rdb or false | string | `""` |
+| `restore.timeout` | Timeout for the restore | int | `600` |
+| `ro_replicas` | Comma separated list of slaves which never get promoted to be master. Count starts with 0. Allowed values 1-9. i.e. 3,4 - 3th and 4th redis slave never make it to be master, where master is index 0. | string | `""` |
+| `schedulerName` | Use an alternate scheduler, e.g. "stork". ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/ | string | `""` |
+| `securityContext` | Security context to be added to the Redis StatefulSet. | object | `{"fsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` |
+| `serviceAccount.annotations` | Annotations to be added to the service account for the redis statefulset | object | `{}` |
+| `serviceAccount.automountToken` | opt in/out of automounting API credentials into container. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ | bool | `false` |
+| `serviceAccount.create` | Specifies whether a ServiceAccount should be created | bool | `true` |
+| `serviceAccount.name` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the valkey-ha.fullname template | string | `""` |
+| `serviceLabels` | Custom labels for redis service | object | `{}` |
+| `splitBrainDetection.interval` | Interval between redis sentinel and server split brain checks (in seconds) | int | `60` |
+| `splitBrainDetection.resources` | splitBrainDetection resources | object | `{}` |
+| `splitBrainDetection.retryInterval` |  | int | `10` |
+| `sysctlImage.command` | sysctlImage command to execute | list | `[]` |
+| `sysctlImage.enabled` | Enable an init container to modify Kernel settings | bool | `false` |
+| `sysctlImage.mountHostSys` | Mount the host `/sys` folder to `/host-sys` | bool | `false` |
+| `sysctlImage.pullPolicy` | sysctlImage Init container pull policy | string | `"Always"` |
+| `sysctlImage.registry` | sysctlImage Init container registry | string | `"public.ecr.aws/docker/library"` |
+| `sysctlImage.repository` | sysctlImage Init container name | string | `"busybox"` |
+| `sysctlImage.resources` | sysctlImage resources | object | `{}` |
+| `sysctlImage.tag` | sysctlImage Init container tag | string | `"1.34.1"` |
+| `tls.caCertFile` | Name of CA certificate file | string | `"ca.crt"` |
+| `tls.certFile` | Name of certificate file | string | `"redis.crt"` |
+| `tls.dhParamsFile` | Name of Diffie-Hellman (DH) key exchange parameters file (Example: redis.dh) | string | `nil` |
+| `tls.keyFile` | Name of key file | string | `"redis.key"` |
+| `tolerations` |  | list | `[]` |
+| `topologySpreadConstraints.enabled` | Enable topology spread constraints | bool | `false` |
+| `topologySpreadConstraints.maxSkew` | Max skew of pods tolerated | string | `""` |
+| `topologySpreadConstraints.topologyKey` | Topology key for spread constraints | string | `""` |
+| `topologySpreadConstraints.whenUnsatisfiable` | Enforcement policy, hard or soft | string | `""` |
+
+### Redis Sentinel parameters
+
+| Parameter | Description | Type | Default |
+|-----|------|---------|-------------|
+| `sentinel.auth` | Enables or disables sentinel AUTH (Requires `sentinel.password` to be set) | bool | `false` |
+| `sentinel.authClients` | It is possible to disable client side certificates authentication when "authClients" is set to "no" | string | `""` |
+| `sentinel.authKey` | The key holding the sentinel password in an existing secret. | string | `"sentinel-password"` |
+| `sentinel.config` | Valid sentinel config options in this section will be applied as config options to each sentinel (see below) | object | see values.yaml |
+| `sentinel.customArgs` |  | list | `[]` |
+| `sentinel.customCommand` |  | list | `[]` |
+| `sentinel.customConfig` | Allows for custom sentinel.conf files to be applied. If this is used then `sentinel.config` is ignored | string | `""` |
+| `sentinel.existingSecret` | An existing secret containing a key defined by `sentinel.authKey` that configures `requirepass` in the conf parameters (Requires `sentinel.auth: enabled`, cannot be used in conjunction with `.Values.sentinel.password`) | string | `""` |
+| `sentinel.extraVolumeMounts` | additional volumeMounts for Sentinel container | list | `[]` |
+| `sentinel.lifecycle` | Container Lifecycle Hooks for sentinel container. Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/ | object | `{}` |
+| `sentinel.livenessProbe.enabled` |  | bool | `true` |
+| `sentinel.livenessProbe.failureThreshold` | Failure threshold for liveness probe | int | `5` |
+| `sentinel.livenessProbe.initialDelaySeconds` | Initial delay in seconds for liveness probe | int | `30` |
+| `sentinel.livenessProbe.periodSeconds` | Period in seconds after which liveness probe will be repeated | int | `15` |
+| `sentinel.livenessProbe.successThreshold` | Success threshold for liveness probe | int | `1` |
+| `sentinel.livenessProbe.timeoutSeconds` | Timeout seconds for liveness probe | int | `15` |
+| `sentinel.password` | A password that configures a `requirepass` in the conf parameters (Requires `sentinel.auth: enabled`) | string | `nil` |
+| `sentinel.resolveHostnames` | Configures sentinel with resolve-hostnames parameter, if true sets "resolve-hostnames yes" in sentinel.conf | bool | `nil` |
+| `sentinel.announceHostnames` | Configures sentinel with announce-hostnames parameter, if true sets "announce-hostnames yes" in sentinel.conf | bool | `nil` |
+| `sentinel.port` | Port to access the sentinel service | int | `26379` |
+| `sentinel.quorum` | Minimum number of nodes expected to be live. | int | `2` |
+| `sentinel.readinessProbe.enabled` |  | bool | `true` |
+| `sentinel.readinessProbe.failureThreshold` | Failure threshold for readiness probe | int | `5` |
+| `sentinel.readinessProbe.initialDelaySeconds` | Initial delay in seconds for readiness probe | int | `30` |
+| `sentinel.readinessProbe.periodSeconds` | Period in seconds after which readiness probe will be repeated | int | `15` |
+| `sentinel.readinessProbe.successThreshold` | Success threshold for readiness probe | int | `3` |
+| `sentinel.readinessProbe.timeoutSeconds` | Timeout seconds for readiness probe | int | `15` |
+| `sentinel.resources` | CPU/Memory for sentinel node resource requests/limits | object | `{}` |
+| `sentinel.startupProbe` | Startup probe parameters for redis container | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":15}` |
+| `sentinel.startupProbe.enabled` | Enable Startup Probe | bool | `true` |
+| `sentinel.startupProbe.failureThreshold` | Failure threshold for startup probe | int | `3` |
+| `sentinel.startupProbe.initialDelaySeconds` | Initial delay in seconds for startup probe | int | `5` |
+| `sentinel.startupProbe.periodSeconds` | Period in seconds after which startup probe will be repeated | int | `10` |
+| `sentinel.startupProbe.successThreshold` | Success threshold for startup probe | int | `1` |
+| `sentinel.startupProbe.timeoutSeconds` | Timeout seconds for startup probe | int | `15` |
+| `sentinel.tlsPort` | TLS Port to access the sentinel service | int | `nil` |
+| `sentinel.tlsReplication` | Configures sentinel with tls-replication parameter, if true sets "tls-replication yes" in sentinel.conf | bool | `nil` |
+
+### HAProxy parameters
+
+| Parameter | Description | Type | Default |
+|-----|------|---------|-------------|
+| `haproxy.IPv6.enabled` | Enable HAProxy parameters to bind and consume IPv6 addresses. Enabled by default. | bool | `true` |
+| `haproxy.additionalAffinities` | Additional affinities to add to the haproxy pods. | object | `{}` |
+| `haproxy.additionalPorts` | Additional ports to expose on HAProxy service and deployment. Each port should have a name, containerPort, and optionally servicePort (defaults to containerPort) | list | `[]` |
+| `haproxy.affinity` | Override all other affinity settings for the haproxy pods with a string. | string | `""` |
+| `haproxy.annotations` | HAProxy template annotations | object | `{}` |
+| `haproxy.checkFall` | haproxy.cfg `check fall` setting | int | `1` |
+| `haproxy.checkInterval` | haproxy.cfg `check inter` setting | string | `"1s"` |
+| `haproxy.containerPort` | Modify HAProxy deployment container port | int | `6379` |
+| `haproxy.containerSecurityContext` | Security context to be added to the HAProxy containers. | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` |
+| `haproxy.customConfig` | Allows for custom config-haproxy.cfg file to be applied. If this is used then default config will be overwriten | string | `nil` |
+| `haproxy.deploymentAnnotations` | HAProxy deployment annotations | object | `{}` |
+| `haproxy.deploymentStrategy` | Deployment strategy for the haproxy deployment | object | `{"type":"RollingUpdate"}` |
+| `haproxy.emptyDir` | Configuration of `emptyDir` | object | `{}` |
+| `haproxy.enabled` | Enabled HAProxy LoadBalancing/Proxy | bool | `false` |
+| `haproxy.extraConfig` | Allows to place any additional configuration section to add to the default config-haproxy.cfg | string | `nil` |
+| `haproxy.hardAntiAffinity` | Whether the haproxy pods should be forced to run on separate nodes. | bool | `true` |
+| `haproxy.image.pullPolicy` | HAProxy Image PullPolicy | string | `"IfNotPresent"` |
+| `haproxy.image.repository` | HAProxy Image Repository | string | `"public.ecr.aws/docker/library/haproxy"` |
+| `haproxy.image.tag` | HAProxy Image Tag | string | `"3.0.8-alpine"` |
+| `haproxy.imagePullSecrets` | Reference to one or more secrets to be used when pulling images ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ | list | `[]` |
+| `haproxy.init.resources` | Extra init resources | object | `{}` |
+| `haproxy.labels` | Custom labels for the haproxy pod | object | `{}` |
+| `haproxy.lifecycle` | Container lifecycle hooks. Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/ | object | `{}` |
+| `haproxy.metrics.enabled` | HAProxy enable prometheus metric scraping | bool | `false` |
+| `haproxy.metrics.port` | HAProxy prometheus metrics scraping port | int | `9101` |
+| `haproxy.metrics.portName` | HAProxy metrics scraping port name | string | `"http-exporter-port"` |
+| `haproxy.metrics.scrapePath` | HAProxy prometheus metrics scraping path | string | `"/metrics"` |
+| `haproxy.metrics.serviceMonitor.disableAPICheck` | Disable API Check on ServiceMonitor | bool | `false` |
+| `haproxy.metrics.serviceMonitor.enabled` | When set true then use a ServiceMonitor to configure scraping | bool | `false` |
+| `haproxy.metrics.serviceMonitor.endpointAdditionalProperties` | Set additional properties for the ServiceMonitor endpoints such as relabeling, scrapeTimeout, tlsConfig, and more. | object | `{}` |
+| `haproxy.metrics.serviceMonitor.interval` | Set how frequently Prometheus should scrape (default is 30s) | string | `""` |
+| `haproxy.metrics.serviceMonitor.labels` | Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator | object | `{}` |
+| `haproxy.metrics.serviceMonitor.namespace` | Set the namespace the ServiceMonitor should be deployed | string | `.Release.Namespace` |
+| `haproxy.metrics.serviceMonitor.telemetryPath` | Set path to redis-exporter telemtery-path (default is /metrics) | string | `""` |
+| `haproxy.metrics.serviceMonitor.timeout` | Set timeout for scrape (default is 10s) | string | `""` |
+| `haproxy.networkPolicy.annotations` | Annotations for Haproxy NetworkPolicy | object | `{}` |
+| `haproxy.networkPolicy.egressRules` | user can define egress rules too, uses the same structure as ingressRules | list | `[]` |
+| `haproxy.networkPolicy.enabled` | whether NetworkPolicy for Haproxy should be created | bool | `false` |
+| `haproxy.networkPolicy.ingressRules` | user defined ingress rules that Haproxy should permit into. uses the format defined in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors | list | `[]` |
+| `haproxy.networkPolicy.labels` | Labels for Haproxy NetworkPolicy | object | `{}` |
+| `haproxy.podAnnotations` | Annotations to be added to the HAProxy deployment pods | object | `{}` |
+| `haproxy.podDisruptionBudget` | Pod Disruption Budget ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/ | object | `{}` |
+| `haproxy.priorityClassName` | Kubernetes priorityClass name for the haproxy pod | string | `""` |
+| `haproxy.readOnly` | Enable read-only redis-slaves | object | `{"enabled":false,"port":6380}` |
+| `haproxy.readOnly.enabled` | Enable if you want a dedicated port in haproxy for redis-slaves | bool | `false` |
+| `haproxy.readOnly.port` | Port for the read-only redis-slaves | int | `6380` |
+| `haproxy.replicas` | Number of HAProxy instances | int | `3` |
+| `haproxy.resources` | HAProxy resources | object | `{}` |
+| `haproxy.securityContext` | Security context to be added to the HAProxy deployment. | object | `{"fsGroup":99,"runAsNonRoot":true,"runAsUser":99}` |
+| `haproxy.service.annotations` | HAProxy service annotations | string | `nil` |
+| `haproxy.service.externalIPs` | HAProxy external IPs | object | `{}` |
+| `haproxy.service.externalTrafficPolicy` | HAProxy service externalTrafficPolicy value (haproxy.service.type must be LoadBalancer) | string | `nil` |
+| `haproxy.service.labels` | HAProxy service labels | object | `{}` |
+| `haproxy.service.loadBalancerIP` | HAProxy service loadbalancer IP | string | `nil` |
+| `haproxy.service.loadBalancerSourceRanges` | List of CIDR's allowed to connect to LoadBalancer | list | `[]` |
+| `haproxy.service.nodePort` | HAProxy service nodePort value (haproxy.service.type must be NodePort) | int | `nil` |
+| `haproxy.service.type` | HAProxy service type "ClusterIP", "LoadBalancer" or "NodePort" | string | `"ClusterIP"` |
+| `haproxy.serviceAccount.automountToken` |  | bool | `true` |
+| `haproxy.serviceAccount.create` | Specifies whether a ServiceAccount should be created | bool | `true` |
+| `haproxy.serviceAccountName` | HAProxy serviceAccountName | string | `"redis-sa"` |
+| `haproxy.servicePort` | Modify HAProxy service port | int | `6379` |
+| `haproxy.stickyBalancing` | HAProxy sticky load balancing to Redis nodes. Helps with connections shutdown. | bool | `false` |
+| `haproxy.tests.resources` | Pod resources for the tests against HAProxy. | object | `{}` |
+| `haproxy.timeout.check` | haproxy.cfg `timeout check` setting | string | `"2s"` |
+| `haproxy.timeout.client` | haproxy.cfg `timeout client` setting | string | `"330s"` |
+| `haproxy.timeout.connect` | haproxy.cfg `timeout connect` setting | string | `"4s"` |
+| `haproxy.timeout.server` | haproxy.cfg `timeout server` setting | string | `"330s"` |
+| `haproxy.timeout.tunnel` | haproxy.cfg `timeout tunnel` setting | string | `"1h"` |
+| `haproxy.tls` | Enable TLS termination on HAproxy, This will create a volume mount | object | `{"certMountPath":"/tmp/","enabled":false,"keyName":null,"secretName":""}` |
+| `haproxy.tls.certMountPath` | Path to mount the secret that contains the certificates. haproxy | string | `"/tmp/"` |
+| `haproxy.tls.enabled` | If "true" this will enable TLS termination on haproxy | bool | `false` |
+| `haproxy.tls.keyName` | Key file name | string | `nil` |
+| `haproxy.tls.secretName` | Secret containing the .pem file | string | `""` |
+
+### Prometheus exporter parameters
+
+| Parameter | Description | Type | Default |
+|-----|------|---------|-------------|
+| `exporter.address` | Address/Host for Redis instance. Exists to circumvent issues with IPv6 dns resolution that occurs on certain environments | string | `"localhost"` |
+| `exporter.enabled` | If `true`, the prometheus exporter sidecar is enabled | bool | `false` |
+| `exporter.extraArgs` | Additional args for redis exporter | object | `{}` |
+| `exporter.image` | Exporter image | string | `"quay.io/oliver006/redis_exporter"` |
+| `exporter.livenessProbe.httpGet.path` | Exporter liveness probe httpGet path | string | `"/metrics"` |
+| `exporter.livenessProbe.httpGet.port` | Exporter liveness probe httpGet port | int | `9121` |
+| `exporter.livenessProbe.initialDelaySeconds` | Initial delay in seconds for liveness probe of exporter | int | `15` |
+| `exporter.livenessProbe.periodSeconds` | Period in seconds after which liveness probe will be repeated | int | `15` |
+| `exporter.livenessProbe.timeoutSeconds` | Timeout seconds for liveness probe of exporter | int | `3` |
+| `exporter.port` | Exporter port | int | `9121` |
+| `exporter.portName` | Exporter port name | string | `"exporter-port"` |
+| `exporter.pullPolicy` | Exporter image pullPolicy | string | `"IfNotPresent"` |
+| `exporter.readinessProbe.httpGet.path` | Exporter readiness probe httpGet path | string | `"/metrics"` |
+| `exporter.readinessProbe.httpGet.port` | Exporter readiness probe httpGet port | int | `9121` |
+| `exporter.readinessProbe.initialDelaySeconds` | Initial delay in seconds for readiness probe of exporter | int | `15` |
+| `exporter.readinessProbe.periodSeconds` | Period in seconds after which readiness probe will be repeated | int | `15` |
+| `exporter.readinessProbe.successThreshold` | Success threshold for readiness probe of exporter | int | `2` |
+| `exporter.readinessProbe.timeoutSeconds` | Timeout seconds for readiness probe of exporter | int | `3` |
+| `exporter.resources` | cpu/memory resource limits/requests | object | `{}` |
+| `exporter.scrapePath` | Exporter scrape path | string | `"/metrics"` |
+| `exporter.script` | A custom custom Lua script that will be mounted to exporter for collection of custom metrics. Creates a ConfigMap and sets env var `REDIS_EXPORTER_SCRIPT`. | string | `""` |
+| `exporter.serviceMonitor.disableAPICheck` | Disable API Check on ServiceMonitor | bool | `false` |
+| `exporter.serviceMonitor.enabled` | When set true then use a ServiceMonitor to configure scraping | bool | `false` |
+| `exporter.serviceMonitor.endpointAdditionalProperties` | Set additional properties for the ServiceMonitor endpoints such as relabeling, scrapeTimeout, tlsConfig, and more. | object | `{}` |
+| `exporter.serviceMonitor.interval` | Set how frequently Prometheus should scrape (default is 30s) | string | `""` |
+| `exporter.serviceMonitor.labels` | Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator | object | `{}` |
+| `exporter.serviceMonitor.metricRelabelings` |  | list | `[]` |
+| `exporter.serviceMonitor.namespace` | Set the namespace the ServiceMonitor should be deployed | string | `.Release.Namespace` |
+| `exporter.serviceMonitor.relabelings` |  | list | `[]` |
+| `exporter.serviceMonitor.telemetryPath` | Set path to redis-exporter telemtery-path (default is /metrics) | string | `""` |
+| `exporter.serviceMonitor.timeout` | Set timeout for scrape (default is 10s) | string | `""` |
+| `exporter.tag` | Exporter image tag | string | `"v1.67.0"` |
+| `prometheusRule.additionalLabels` | Additional labels to be set in metadata. | object | `{}` |
+| `prometheusRule.enabled` | If true, creates a Prometheus Operator PrometheusRule. | bool | `false` |
+| `prometheusRule.interval` | How often rules in the group are evaluated (falls back to `global.evaluation_interval` if not set). | string | `"10s"` |
+| `prometheusRule.namespace` | Namespace which Prometheus is running in. | string | `nil` |
+| `prometheusRule.rules` | Rules spec template (see https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule). | list | `[]` |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm repo add dandydev https://dandydeveloper.github.io/charts
+$ helm install \
+  --set image=valkey/valkey \
+  --set tag=8.1.8-alpine \
+    dandydev/valkey-ha
+```
+
+The above command sets the Valkey server within `default` namespace.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+helm install -f values.yaml dandydev/valkey-ha
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Custom Redis and Sentinel config options
+
+This chart allows for most redis or sentinel config options to be passed as a key value pair through the `values.yaml` under `redis.config` and `sentinel.config`. See links below for all available options.
+
+[Example redis.conf](http://download.redis.io/redis-stable/redis.conf)
+[Example sentinel.conf](http://download.redis.io/redis-stable/sentinel.conf)
+
+For example `repl-timeout 60` would be added to the `redis.config` section of the `values.yaml` as:
+
+```yml
+    repl-timeout: "60"
+```
+
+Note:
+
+1. Some config options should be renamed by redis version，e.g.:
+
+   ```yml
+   # In redis 5.x，see https://raw.githubusercontent.com/antirez/redis/5.0/redis.conf
+   min-replicas-to-write: 1
+   min-replicas-max-lag: 5
+
+   # In redis 4.x and redis 3.x，see https://raw.githubusercontent.com/antirez/redis/4.0/redis.conf and https://raw.githubusercontent.com/antirez/redis/3.0/redis.conf
+   min-slaves-to-write 1
+   min-slaves-max-lag 5
+   ```
+
+Sentinel options supported must be in the the `sentinel <option> <master-group-name> <value>` format. For example, `sentinel down-after-milliseconds 30000` would be added to the `sentinel.config` section of the `values.yaml` as:
+
+```yml
+    down-after-milliseconds: 30000
+```
+
+If more control is needed from either the redis or sentinel config then an entire config can be defined under `redis.customConfig` or `sentinel.customConfig`. Please note that these values will override any configuration options under their respective section. For example, if you define `sentinel.customConfig` then the `sentinel.config` is ignored.
+
+## Host Kernel Settings
+
+Redis may require some changes in the kernel of the host machine to work as expected, in particular increasing the `somaxconn` value and disabling transparent huge pages.
+To do so, you can set up a privileged initContainer with the `sysctlImage` config values, for example:
+
+```yml
+sysctlImage:
+  enabled: true
+  mountHostSys: true
+  command:
+    - /bin/sh
+    - -xc
+    - |-
+      sysctl -w net.core.somaxconn=10000
+      echo never > /host-sys/kernel/mm/transparent_hugepage/enabled
+```
+
+## HAProxy startup
+
+When HAProxy is enabled, it will attempt to connect to each announce-service of each redis replica instance in its init container before starting.
+It will fail if announce-service IP is not available fast enough (10 seconds max by announce-service).
+A such case could happen if the orchestator is pending the nomination of redis pods.
+Risk is limited because announce-service is using `publishNotReadyAddresses: true`, although, in such case, HAProxy pod will be rescheduled afterward by the orchestrator.
+
+PodDisruptionBudgets are not configured by default, you may need to set the `haproxy.podDisruptionBudget` parameter in values.yaml to enable it.
+
+## Network policies
+
+If `networkPolicy.enabled` is set to `true`, then a `NetworkPolicy` resource is created with default rules to allow inter-Redis and Sentinel connectivity.
+This is a requirement for Redis Pods to come up successfully.
+
+You will need to define `ingressRules` to permit your application connectivity to Redis.
+The `selectors` block should be in the format of a [label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors).
+Templating is also supported in the selectors.
+See such a configuration below.
+
+```yaml
+networkPolicy: true
+  ingressRules:
+    - selectors:
+      - namespaceSelector:
+          matchLabels:
+            name: my-redis-client-namespace
+        podSelector:
+          matchLabels:
+            # template example
+            app: |-
+              {{- .App.Name }}
+      ## ports block is optional (defaults to below), define the block to override the defaults
+      # ports:
+      #   - port: 6379
+      #     protocol: TCP
+      #   - port: 26379
+      #     protocol: TCP
+```
+
+Should your Pod require additional egress rules, define them in a `egressRules` key which is structured identically to an `ingressRules` key.
+
+## Sentinel and redis server split brain detection
+
+Under not entirely known yet circumstances redis sentinel and its corresponding redis server reach a condition that this chart authors call "split brain" (for short). The observed behaviour is the following: the sentinel switches to the new re-elected master, but does not switch its redis server. Majority of original discussion on the problem has happened at the #121.
+
+The proposed solution is currently implemented as a sidecar container that runs a bash script with the following logic:
+
+1. At intervals defined by splitBrainDetection.interval, the sidecar checks which node is recognized as master by Sentinel.
+2. If the current pod is the master according to Sentinel, it verifies that the local Redis server is also running as master.
+3. If the current pod is not the master, it ensures the local Redis server is replicating from the correct master node.
+4. If any of these checks fail, the sidecar will retry the check at intervals defined by splitBrainDetection.retryInterval.
+5. If the checks continue to fail after the retry attempts, the sidecar triggers a reinitialization: it regenerates the Redis configuration and instructs the Redis server to shut down. Kubernetes will then automatically restart the container.
+
+# Change Log
+
+## 4.14.9 - ** POTENTIAL BREAKING CHANGE. **
+Introduced the ability to change the Haproxy Deployment container pod
+- Container port in valkey-haproxy-deployment.yam has been changed. Was **redis.port** To **haproxy.containerPort**. Default value is 6379.
+- Port in valkey-haproxy-service.yaml has been changed. Was **redis.port** To **haproxy.servicePort**. Default value is 6379.
+
+## 4.21.0 - BREAKING CHANGES (Kubernetes Deprecation)
+This version introduced the deprecation of the PSP and subsequently added fields to the securityContexts that were introduced in Kubernetes v1.19:
+
+https://kubernetes.io/docs/tutorials/security/seccomp/
+
+As a result, from this version onwards Kubernetes versions older than 1.19 will fail to install without the removal of `.Values.containerSecurityContext.seccompProfile` and `.Values.haproxy.containerSecurityContext.seccompProfile` (If HAProxy is enabled)
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs](https://github.com/norwoodj/helm-docs)

--- a/charts/valkey-ha/README.md
+++ b/charts/valkey-ha/README.md
@@ -359,7 +359,7 @@ The following table lists the configurable parameters of the Valkey chart and th
 | `prometheusRule.enabled` | If true, creates a Prometheus Operator PrometheusRule. | bool | `false` |
 | `prometheusRule.interval` | How often rules in the group are evaluated (falls back to `global.evaluation_interval` if not set). | string | `"10s"` |
 | `prometheusRule.namespace` | Namespace which Prometheus is running in. | string | `nil` |
-| `prometheusRule.rules` | Rules spec template (see https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule). | list | `[]` |
+| `prometheusRule.rules` | Rules spec template (see https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule). | list | a set of sensible Valkey alerts (see values.yaml). Requires `exporter.enabled: true` so the metrics exist. |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -415,6 +415,17 @@ Sentinel options supported must be in the the `sentinel <option> <master-group-n
 ```
 
 If more control is needed from either the redis or sentinel config then an entire config can be defined under `redis.customConfig` or `sentinel.customConfig`. Please note that these values will override any configuration options under their respective section. For example, if you define `sentinel.customConfig` then the `sentinel.config` is ignored.
+
+## Migrating from redis-ha / Redis
+
+Valkey is a drop-in, RESP-compatible replacement for Redis, so migrating is mostly a matter of swapping the chart:
+
+- **Values** — this chart keeps the same interface as `redis-ha` (the `redis.*` / `sentinel.*` keys, `auth`, `tls`, `exporter`, `haproxy`, …), so an existing `redis-ha` values file works unchanged.
+- **Clients** — no application changes are required. `redis-cli` and every Redis client library talk to Valkey unmodified, and Valkey reports `redis_version` in `INFO` for backwards compatibility.
+- **Data** — Valkey reads existing Redis `dump.rdb` and `appendonly.aof` files; there is no on-disk conversion step. To carry your data over you can either:
+  - reuse the existing data PersistentVolumes, or
+  - restore from a snapshot at install time via `restore.s3` / `restore.ssh` (an RDB file), or
+  - live-migrate by pulling from a running Redis instance with `restore.redis.source: redis://[user:pass@]host:port`, after which Sentinel promotes a Valkey primary.
 
 ## Valkey-native options
 
@@ -499,6 +510,9 @@ The proposed solution is currently implemented as a sidecar container that runs 
 5. If the checks continue to fail after the retry attempts, the sidecar triggers a reinitialization: it regenerates the Redis configuration and instructs the Redis server to shut down. Kubernetes will then automatically restart the container.
 
 # Change Log
+
+## 1.0.0
+Initial release of the Valkey HA chart, derived from `redis-ha`. Ships the official `valkey/valkey` image and the native `valkey-server` / `valkey-sentinel` / `valkey-cli` binaries, uses Valkey's canonical `replicaof` / `replica-announce-*` replication directives, and exposes Valkey 8.x options (dual-channel replication, I/O threads, availability-zone). The `values.yaml` interface remains drop-in compatible with `redis-ha`. The entries below are inherited from the `redis-ha` lineage for historical reference.
 
 ## 4.14.9 - ** POTENTIAL BREAKING CHANGE. **
 Introduced the ability to change the Haproxy Deployment container pod

--- a/charts/valkey-ha/README.md.gotmpl
+++ b/charts/valkey-ha/README.md.gotmpl
@@ -18,7 +18,7 @@ By default this chart install 3 pods total:
 
 ## Introduction
 
-This chart bootstraps a [Valkey](https://valkey.io/) highly available master/slave statefulset in a [Kubernetes](http://kubernetes.io) cluster using the Helm package manager.
+This chart bootstraps a [Valkey](https://valkey.io/) highly available primary/replica statefulset in a [Kubernetes](http://kubernetes.io) cluster using the Helm package manager.
 
 ## Prerequisites
 
@@ -43,7 +43,7 @@ helm repo add dandydev https://dandydeveloper.github.io/charts
 helm install dandydev/valkey-ha
 ```
 
-The command deploys Redis on the Kubernetes cluster in the default configuration. By default this chart install one master pod containing redis master container and sentinel container along with 2 redis slave pods each containing their own sentinel sidecars. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The command deploys Valkey on the Kubernetes cluster in the default configuration. By default this chart install one primary pod containing a valkey master container and sentinel container along with 2 valkey replica pods each containing their own sentinel sidecars. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
@@ -59,7 +59,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following table lists the configurable parameters of the Redis chart and their default values.
+The following table lists the configurable parameters of the Valkey chart and their default values.
 
 ### General parameters
 
@@ -155,6 +155,18 @@ Sentinel options supported must be in the the `sentinel <option> <master-group-n
 ```
 
 If more control is needed from either the redis or sentinel config then an entire config can be defined under `redis.customConfig` or `sentinel.customConfig`. Please note that these values will override any configuration options under their respective section. For example, if you define `sentinel.customConfig` then the `sentinel.config` is ignored.
+
+## Valkey-native options
+
+This chart ships the official [`valkey/valkey`](https://hub.docker.com/r/valkey/valkey) image and exposes a few [Valkey 8.x](https://valkey.io/blog/valkey-8-0-0-rc1/) features under `redis.config`:
+
+- **Dual-channel replication** (`dual-channel-replication-enabled`): streams the RDB and the replication backlog on separate channels to speed up full syncs. Disabled by default.
+- **I/O threads** (`io-threads`): Valkey 8.0 reworked I/O threading for substantially higher throughput on multi-core nodes. Defaults to `1` (disabled); raise it towards the number of cores allocated to the pod.
+- **Availability zone** (`availability-zone`): an AZ hint reported via `INFO` and used by AZ-aware clients (e.g. valkey-glide) for locality-aware reads. A single value applies to every replica, so set it only when pods are pinned to one zone (otherwise inject a per-pod value via `redis.customConfig`).
+
+Replication is configured using Valkey's canonical `replicaof` / `replica-announce-*` directives.
+
+To use the [Valkey module bundle](https://hub.docker.com/r/valkey/valkey-bundle) (JSON, search, bloom, …) set `image.repository: valkey/valkey-bundle` and load the modules via the `redis.config.loadmodule` list.
 
 ## Host Kernel Settings
 

--- a/charts/valkey-ha/README.md.gotmpl
+++ b/charts/valkey-ha/README.md.gotmpl
@@ -156,6 +156,17 @@ Sentinel options supported must be in the the `sentinel <option> <master-group-n
 
 If more control is needed from either the redis or sentinel config then an entire config can be defined under `redis.customConfig` or `sentinel.customConfig`. Please note that these values will override any configuration options under their respective section. For example, if you define `sentinel.customConfig` then the `sentinel.config` is ignored.
 
+## Migrating from redis-ha / Redis
+
+Valkey is a drop-in, RESP-compatible replacement for Redis, so migrating is mostly a matter of swapping the chart:
+
+- **Values** — this chart keeps the same interface as `redis-ha` (the `redis.*` / `sentinel.*` keys, `auth`, `tls`, `exporter`, `haproxy`, …), so an existing `redis-ha` values file works unchanged.
+- **Clients** — no application changes are required. `redis-cli` and every Redis client library talk to Valkey unmodified, and Valkey reports `redis_version` in `INFO` for backwards compatibility.
+- **Data** — Valkey reads existing Redis `dump.rdb` and `appendonly.aof` files; there is no on-disk conversion step. To carry your data over you can either:
+  - reuse the existing data PersistentVolumes, or
+  - restore from a snapshot at install time via `restore.s3` / `restore.ssh` (an RDB file), or
+  - live-migrate by pulling from a running Redis instance with `restore.redis.source: redis://[user:pass@]host:port`, after which Sentinel promotes a Valkey primary.
+
 ## Valkey-native options
 
 This chart ships the official [`valkey/valkey`](https://hub.docker.com/r/valkey/valkey) image and exposes a few [Valkey 8.x](https://valkey.io/blog/valkey-8-0-0-rc1/) features under `redis.config`:
@@ -240,6 +251,9 @@ The proposed solution is currently implemented as a sidecar container that runs 
 
 
 # Change Log
+
+## 1.0.0
+Initial release of the Valkey HA chart, derived from `redis-ha`. Ships the official `valkey/valkey` image and the native `valkey-server` / `valkey-sentinel` / `valkey-cli` binaries, uses Valkey's canonical `replicaof` / `replica-announce-*` replication directives, and exposes Valkey 8.x options (dual-channel replication, I/O threads, availability-zone). The `values.yaml` interface remains drop-in compatible with `redis-ha`. The entries below are inherited from the `redis-ha` lineage for historical reference.
 
 ## 4.14.9 - ** POTENTIAL BREAKING CHANGE. **
 Introduced the ability to change the Haproxy Deployment container pod

--- a/charts/valkey-ha/README.md.gotmpl
+++ b/charts/valkey-ha/README.md.gotmpl
@@ -1,0 +1,245 @@
+# Valkey
+
+[Valkey](https://valkey.io/) is an open source (BSD), high-performance key/value datastore and a drop-in replacement for Redis. It supports strings, hashes, lists, sets, sorted sets, bitmaps, hyperloglogs and more, speaking the same RESP protocol so existing Redis clients and tooling work unmodified.
+
+This chart is a Valkey-flavoured copy of the `redis-ha` chart. It keeps the same `values.yaml` interface (the `redis.*` / `sentinel.*` keys are preserved) so it can be used as a drop-in replacement, while shipping the official [`valkey/valkey`](https://hub.docker.com/r/valkey/valkey) image and the native `valkey-server`/`valkey-sentinel`/`valkey-cli` binaries.
+
+## TL;DR
+
+```bash
+helm repo add dandydev https://dandydeveloper.github.io/charts
+helm install dandydev/valkey-ha
+```
+
+By default this chart install 3 pods total:
+
+* one pod containing a valkey master and sentinel container (optional prometheus metrics exporter sidecar available)
+* two pods each containing a valkey slave and sentinel containers (optional prometheus metrics exporter sidecars available)
+
+## Introduction
+
+This chart bootstraps a [Valkey](https://valkey.io/) highly available master/slave statefulset in a [Kubernetes](http://kubernetes.io) cluster using the Helm package manager.
+
+## Prerequisites
+
+* Kubernetes 1.8+ with Beta APIs enabled
+* PV provisioner support in the underlying infrastructure
+* Helm v3+
+
+## Upgrading the Chart
+
+Please note that there have been a number of changes simplifying the redis management strategy (for better failover and elections) in the 3.x version of this chart. These changes allow the use of official [redis](https://hub.docker.com/_/redis/) images that do not require special RBAC or ServiceAccount roles. As a result when upgrading from version >=2.0.1 to >=3.0.0 of this chart, `Role`, `RoleBinding`, and `ServiceAccount` resources should be deleted manually.
+
+### Upgrading the chart from 3.x to 4.x
+
+Starting from version `4.x` HAProxy sidecar prometheus-exporter removed and replaced by the embedded [HAProxy metrics endpoint](https://github.com/haproxy/haproxy/tree/master/contrib/prometheus-exporter), as a result when upgrading from version 3.x to 4.x section `haproxy.exporter` should be removed and the `haproxy.metrics` need to be configured for fit your needs.
+
+## Installing the Chart
+
+To install the chart
+
+```bash
+helm repo add dandydev https://dandydeveloper.github.io/charts
+helm install dandydev/valkey-ha
+```
+
+The command deploys Redis on the Kubernetes cluster in the default configuration. By default this chart install one master pod containing redis master container and sentinel container along with 2 redis slave pods each containing their own sentinel sidecars. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the deployment:
+
+```bash
+helm delete <chart-name>
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Redis chart and their default values.
+
+### General parameters
+
+| Parameter | Description | Type | Default |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if not (or  (hasPrefix "haproxy" .Key) (hasPrefix "sentinel" .Key) (hasPrefix "exporter" .Key) (hasPrefix "prometheusRule" .Key) ) }}
+| `{{ .Key }}` | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### Redis Sentinel parameters
+
+| Parameter | Description | Type | Default |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "sentinel" .Key }}
+| `{{ .Key }}` | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### HAProxy parameters
+
+| Parameter | Description | Type | Default |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "haproxy" .Key }}
+| `{{ .Key }}` | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### Prometheus exporter parameters
+
+| Parameter | Description | Type | Default |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if or (hasPrefix "exporter" .Key) (hasPrefix "prometheusRule" .Key) }}
+| `{{ .Key }}` | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm repo add dandydev https://dandydeveloper.github.io/charts
+$ helm install \
+  --set image=valkey/valkey \
+  --set tag=8.1.8-alpine \
+    dandydev/valkey-ha
+```
+
+The above command sets the Valkey server within `default` namespace.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+helm install -f values.yaml dandydev/valkey-ha
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Custom Redis and Sentinel config options
+
+This chart allows for most redis or sentinel config options to be passed as a key value pair through the `values.yaml` under `redis.config` and `sentinel.config`. See links below for all available options.
+
+[Example redis.conf](http://download.redis.io/redis-stable/redis.conf)
+[Example sentinel.conf](http://download.redis.io/redis-stable/sentinel.conf)
+
+For example `repl-timeout 60` would be added to the `redis.config` section of the `values.yaml` as:
+
+```yml
+    repl-timeout: "60"
+```
+
+Note:
+
+1. Some config options should be renamed by redis version，e.g.:
+
+   ```yml
+   # In redis 5.x，see https://raw.githubusercontent.com/antirez/redis/5.0/redis.conf
+   min-replicas-to-write: 1
+   min-replicas-max-lag: 5
+
+   # In redis 4.x and redis 3.x，see https://raw.githubusercontent.com/antirez/redis/4.0/redis.conf and https://raw.githubusercontent.com/antirez/redis/3.0/redis.conf
+   min-slaves-to-write 1
+   min-slaves-max-lag 5
+   ```
+
+Sentinel options supported must be in the the `sentinel <option> <master-group-name> <value>` format. For example, `sentinel down-after-milliseconds 30000` would be added to the `sentinel.config` section of the `values.yaml` as:
+
+```yml
+    down-after-milliseconds: 30000
+```
+
+If more control is needed from either the redis or sentinel config then an entire config can be defined under `redis.customConfig` or `sentinel.customConfig`. Please note that these values will override any configuration options under their respective section. For example, if you define `sentinel.customConfig` then the `sentinel.config` is ignored.
+
+## Host Kernel Settings
+
+Redis may require some changes in the kernel of the host machine to work as expected, in particular increasing the `somaxconn` value and disabling transparent huge pages.
+To do so, you can set up a privileged initContainer with the `sysctlImage` config values, for example:
+
+```yml
+sysctlImage:
+  enabled: true
+  mountHostSys: true
+  command:
+    - /bin/sh
+    - -xc
+    - |-
+      sysctl -w net.core.somaxconn=10000
+      echo never > /host-sys/kernel/mm/transparent_hugepage/enabled
+```
+
+## HAProxy startup
+
+When HAProxy is enabled, it will attempt to connect to each announce-service of each redis replica instance in its init container before starting.
+It will fail if announce-service IP is not available fast enough (10 seconds max by announce-service).
+A such case could happen if the orchestator is pending the nomination of redis pods.
+Risk is limited because announce-service is using `publishNotReadyAddresses: true`, although, in such case, HAProxy pod will be rescheduled afterward by the orchestrator.
+
+PodDisruptionBudgets are not configured by default, you may need to set the `haproxy.podDisruptionBudget` parameter in values.yaml to enable it.
+
+## Network policies
+
+If `networkPolicy.enabled` is set to `true`, then a `NetworkPolicy` resource is created with default rules to allow inter-Redis and Sentinel connectivity.
+This is a requirement for Redis Pods to come up successfully.
+
+You will need to define `ingressRules` to permit your application connectivity to Redis.
+The `selectors` block should be in the format of a [label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors).
+Templating is also supported in the selectors.
+See such a configuration below.
+
+```yaml
+networkPolicy: true
+  ingressRules:
+    - selectors:
+      - namespaceSelector:
+          matchLabels:
+            name: my-valkey-client-namespace
+        podSelector:
+          matchLabels:
+            # template example
+            app: |-
+              {{ printf "{{- .App.Name }}" }}
+      ## ports block is optional (defaults to below), define the block to override the defaults
+      # ports:
+      #   - port: 6379
+      #     protocol: TCP
+      #   - port: 26379
+      #     protocol: TCP
+```
+
+Should your Pod require additional egress rules, define them in a `egressRules` key which is structured identically to an `ingressRules` key.
+
+## Sentinel and redis server split brain detection
+
+Under not entirely known yet circumstances redis sentinel and its corresponding redis server reach a condition that this chart authors call "split brain" (for short). The observed behaviour is the following: the sentinel switches to the new re-elected master, but does not switch its redis server. Majority of original discussion on the problem has happened at the #121.
+
+The proposed solution is currently implemented as a sidecar container that runs a bash script with the following logic:
+
+1. At intervals defined by splitBrainDetection.interval, the sidecar checks which node is recognized as master by Sentinel.
+2. If the current pod is the master according to Sentinel, it verifies that the local Redis server is also running as master.
+3. If the current pod is not the master, it ensures the local Redis server is replicating from the correct master node.
+4. If any of these checks fail, the sidecar will retry the check at intervals defined by splitBrainDetection.retryInterval.
+5. If the checks continue to fail after the retry attempts, the sidecar triggers a reinitialization: it regenerates the Redis configuration and instructs the Redis server to shut down. Kubernetes will then automatically restart the container.
+
+
+# Change Log
+
+## 4.14.9 - ** POTENTIAL BREAKING CHANGE. **
+Introduced the ability to change the Haproxy Deployment container pod
+- Container port in valkey-haproxy-deployment.yam has been changed. Was **redis.port** To **haproxy.containerPort**. Default value is 6379.
+- Port in valkey-haproxy-service.yaml has been changed. Was **redis.port** To **haproxy.servicePort**. Default value is 6379.
+
+## 4.21.0 - BREAKING CHANGES (Kubernetes Deprecation)
+This version introduced the deprecation of the PSP and subsequently added fields to the securityContexts that were introduced in Kubernetes v1.19:
+
+https://kubernetes.io/docs/tutorials/security/seccomp/
+
+As a result, from this version onwards Kubernetes versions older than 1.19 will fail to install without the removal of `.Values.containerSecurityContext.seccompProfile` and `.Values.haproxy.containerSecurityContext.seccompProfile` (If HAProxy is enabled)
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs](https://github.com/norwoodj/helm-docs)

--- a/charts/valkey-ha/ci/haproxy-enabled-values.yaml
+++ b/charts/valkey-ha/ci/haproxy-enabled-values.yaml
@@ -1,0 +1,10 @@
+---
+## Enable HAProxy to manage Load Balancing
+haproxy:
+  enabled: true
+  annotations:
+    any.domain/key: "value"
+  serviceAccount:
+    create: true
+  metrics:
+    enabled: true

--- a/charts/valkey-ha/ci/multi-value-configs-values.yaml
+++ b/charts/valkey-ha/ci/multi-value-configs-values.yaml
@@ -1,0 +1,14 @@
+---
+## Testing if muti-valued config is working or not
+redis:
+  config:
+    min-replicas-to-write: 1
+    min-replicas-max-lag: 5
+    maxmemory: "0"
+    maxmemory-policy: "volatile-lru"
+    save:
+      - "900 1"
+      - "300 10"
+    repl-diskless-sync: "yes"
+    rdbcompression: "yes"
+    rdbchecksum: "yes"

--- a/charts/valkey-ha/ci/valkey-native-values.yaml
+++ b/charts/valkey-ha/ci/valkey-native-values.yaml
@@ -1,0 +1,23 @@
+# Exercises the Valkey-native config options together with AUTH and the
+# metrics exporter sidecar. CRD-dependent features (serviceMonitor,
+# prometheusRule) are intentionally left disabled so this installs on a
+# vanilla kind cluster during chart-testing.
+auth: true
+redisPassword: "ci-test-password"
+
+replicas: 3
+
+redis:
+  config:
+    # Valkey 8.x native tuning
+    dual-channel-replication-enabled: "yes"
+    io-threads: 2
+    maxmemory: "128mb"
+    maxmemory-policy: "allkeys-lru"
+
+sentinel:
+  auth: true
+  password: "ci-sentinel-password"
+
+exporter:
+  enabled: true

--- a/charts/valkey-ha/templates/NOTES.txt
+++ b/charts/valkey-ha/templates/NOTES.txt
@@ -1,0 +1,25 @@
+Valkey can be accessed via {{ if ne (int .Values.redis.port) 0 }}port {{ .Values.redis.port }}{{ end }}  {{ if .Values.redis.tlsPort }} tls-port {{ .Values.redis.tlsPort }}{{ end }} and Sentinel can be accessed via {{ if ne (int .Values.sentinel.port) 0 }}port {{ .Values.sentinel.port }}{{ end }}  {{ if .Values.sentinel.tlsPort }} tls-port {{ .Values.sentinel.tlsPort }}{{ end }}  on the following DNS name from within your cluster:
+{{ template "valkey-ha.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+To connect to your Valkey server:
+
+{{- if .Values.auth }}
+1. To retrieve the valkey password:
+   echo $(kubectl get secret {{ template "valkey-ha.fullname" . }} -o "jsonpath={.data['auth']}" | base64 --decode)
+
+2. Connect to the Valkey master pod that you can use as a client. By default the {{ template "valkey-ha.fullname" . }}-server-0 pod is configured as the master:
+
+   kubectl exec -it {{ template "valkey-ha.fullname" . }}-server-0 -n {{ .Release.Namespace }} -c redis -- sh
+
+3. Connect using the Valkey CLI (inside container):
+
+   valkey-cli -a <VALKEY-PASS-FROM-SECRET>
+{{- else }}
+1. Run a Valkey pod that you can use as a client:
+
+   kubectl exec -it {{ template "valkey-ha.fullname" . }}-server-0 -n {{ .Release.Namespace }} -c redis -- sh
+
+2. Connect using the Valkey CLI:
+
+  valkey-cli -h {{ template "valkey-ha.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end }}

--- a/charts/valkey-ha/templates/_configs.tpl
+++ b/charts/valkey-ha/templates/_configs.tpl
@@ -1,0 +1,801 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "config-redis.conf" }}
+{{- if .Values.redis.customConfig }}
+{{ tpl .Values.redis.customConfig . | indent 4 }}
+{{- else }}
+    dir "/data"
+    port {{ .Values.redis.port }}
+    {{- if .Values.sentinel.tlsPort }}
+    tls-port {{ .Values.redis.tlsPort }}
+    tls-cert-file /tls-certs/{{ .Values.tls.certFile }}
+    tls-key-file /tls-certs/{{ .Values.tls.keyFile }}
+    {{- if .Values.tls.dhParamsFile }}
+    tls-dh-params-file /tls-certs/{{ .Values.tls.dhParamsFile }}
+    {{- end }}
+    {{- if .Values.tls.caCertFile }}
+    tls-ca-cert-file /tls-certs/{{ .Values.tls.caCertFile }}
+    {{- end }}
+    {{- if eq (default "yes" .Values.redis.authClients) "no"}}
+    tls-auth-clients no
+    {{- end }}
+    tls-replication {{ if .Values.redis.tlsReplication }}yes{{ else }}no{{ end }}
+    {{- end }}
+    {{- if .Values.redis.disableCommands }}
+    {{- range .Values.redis.disableCommands }}
+    rename-command {{ . }} ""
+    {{- end }}
+    {{- end }}
+    {{- range $key, $value := .Values.redis.config }}
+    {{- if kindIs "slice" $value }}
+        {{- range $value }}
+    {{ $key }} {{ . }}
+        {{- end }}
+        {{- else }}
+    {{ $key }} {{ $value }}
+        {{- end }}
+    {{- end }}
+{{- if .Values.auth }}
+    requirepass replace-default-auth
+    masterauth replace-default-auth
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "config-sentinel.conf" }}
+{{- if .Values.sentinel.customConfig }}
+{{ tpl .Values.sentinel.customConfig . | indent 4 }}
+{{- else }}
+    dir "/data"
+    port {{ .Values.sentinel.port }}
+    {{- if .Values.sentinel.bind }}
+    bind {{ .Values.sentinel.bind }}
+    {{- end }}
+    {{- if .Values.sentinel.tlsPort }}
+    tls-port {{ .Values.sentinel.tlsPort }}
+    tls-cert-file /tls-certs/{{ .Values.tls.certFile }}
+    tls-key-file /tls-certs/{{ .Values.tls.keyFile }}
+    {{- if .Values.tls.dhParamsFile }}
+    tls-dh-params-file /tls-certs/{{ .Values.tls.dhParamsFile }}
+    {{- end }}
+    {{- if .Values.tls.caCertFile }}
+    tls-ca-cert-file /tls-certs/{{ .Values.tls.caCertFile }}
+    {{- end }}
+    {{- if eq (default "yes" .Values.sentinel.authClients) "no"}}
+    tls-auth-clients no
+    {{- end }}
+    tls-replication {{ if .Values.sentinel.tlsReplication }}yes{{ else }}no{{ end }}
+    {{- end }}
+    {{- range $key, $value := .Values.sentinel.config }}
+    {{- if eq "maxclients" $key  }}
+    {{ $key }} {{ $value }}
+    {{- else }}
+    sentinel {{ $key }} {{ template "valkey-ha.masterGroupName" $ }} {{ $value }}
+    {{- end }}
+    {{- end }}
+{{- if .Values.auth }}
+    sentinel auth-pass {{ template "valkey-ha.masterGroupName" . }} replace-default-auth
+{{- end }}
+{{- if .Values.sentinel.auth }}
+    requirepass replace-default-sentinel-auth
+{{- end }}
+{{- if .Values.sentinel.resolveHostnames }}
+    sentinel resolve-hostnames yes
+{{- end }}
+{{- if .Values.sentinel.announceHostnames }}
+    sentinel announce-hostnames yes
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "lib.sh" }}
+    sentinel_get_master() {
+    set +e
+        if [ "$SENTINEL_PORT" -eq 0 ]; then
+            if [ "$RESOLVE_HOSTNAMES" = true ]; then
+                valkey-cli -h "${SERVICE}" -p "${SENTINEL_TLS_PORT}" {{ if .Values.sentinel.auth }} -a "${SENTINELAUTH}" --no-auth-warning{{ end }} --tls --cacert /tls-certs/{{ .Values.tls.caCertFile }} {{ if ne (default "yes" .Values.sentinel.authClients) "no"}} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}{{ end }} sentinel get-master-addr-by-name "${MASTER_GROUP}" |\
+                head -n 1 | grep -E '^\s*[a-zA-Z0-9.-]+\s*$'
+            else
+                valkey-cli -h "${SERVICE}" -p "${SENTINEL_TLS_PORT}" {{ if .Values.sentinel.auth }} -a "${SENTINELAUTH}" --no-auth-warning{{ end }} --tls --cacert /tls-certs/{{ .Values.tls.caCertFile }} {{ if ne (default "yes" .Values.sentinel.authClients) "no"}} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}{{ end }} sentinel get-master-addr-by-name "${MASTER_GROUP}" |\
+                head -n 1 | grep -E '((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?s*$))'
+            fi
+        else
+            if [ "$RESOLVE_HOSTNAMES" = true ]; then
+                valkey-cli -h "${SERVICE}" -p "${SENTINEL_PORT}" {{ if .Values.sentinel.auth }} -a "${SENTINELAUTH}" --no-auth-warning{{ end }} sentinel get-master-addr-by-name "${MASTER_GROUP}" |\
+                head -n 1 | grep -E '^\s*[a-zA-Z0-9.-]+\s*$'
+            else
+                valkey-cli -h "${SERVICE}" -p "${SENTINEL_PORT}" {{ if .Values.sentinel.auth }} -a "${SENTINELAUTH}" --no-auth-warning{{ end }} sentinel get-master-addr-by-name "${MASTER_GROUP}" |\
+                head -n 1 | grep -E '((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?s*$))'
+            fi
+        fi
+    set -e
+    }
+
+    sentinel_get_master_retry() {
+        master=''
+        retry=${1}
+        sleep=3
+        for i in $(seq 1 "${retry}"); do
+            master=$(sentinel_get_master)
+            if [ -n "${master}" ]; then
+                break
+            fi
+            sleep $((sleep + i))
+        done
+        echo "${master}"
+    }
+
+    identify_master() {
+        echo "Identifying redis master (get-master-addr-by-name).."
+        echo "  using sentinel ({{ template "valkey-ha.fullname" . }}), sentinel group name ({{ template "valkey-ha.masterGroupName" . }})"
+        MASTER="$(sentinel_get_master_retry 3)"
+        if [ -n "${MASTER}" ]; then
+            echo "  $(date) Found redis master (${MASTER})"
+        else
+            echo "  $(date) Did not find redis master (${MASTER})"
+        fi
+    }
+
+    sentinel_update() {
+        echo "Updating sentinel config.."
+        echo "  evaluating sentinel id (\${SENTINEL_ID_${INDEX}})"
+        eval MY_SENTINEL_ID="\$SENTINEL_ID_${INDEX}"
+        echo "  sentinel id (${MY_SENTINEL_ID}), sentinel grp (${MASTER_GROUP}), quorum (${QUORUM})"
+        sed -i "1s/^/sentinel myid ${MY_SENTINEL_ID}\\n/" "${SENTINEL_CONF}"
+        if [ "$SENTINEL_TLS_REPLICATION_ENABLED" = true ]; then
+            echo "  redis master (${1}:${REDIS_TLS_PORT})"
+            sed -i "2s/^/sentinel monitor ${MASTER_GROUP} ${1} ${REDIS_TLS_PORT} ${QUORUM} \\n/" "${SENTINEL_CONF}"
+        else
+            echo "  redis master (${1}:${REDIS_PORT})"
+            sed -i "2s/^/sentinel monitor ${MASTER_GROUP} ${1} ${REDIS_PORT} ${QUORUM} \\n/" "${SENTINEL_CONF}"
+        fi
+        echo "sentinel announce-ip ${ANNOUNCE_IP}" >> ${SENTINEL_CONF}
+        if [ "$SENTINEL_PORT" -eq 0 ]; then
+            echo "  announce (${ANNOUNCE_IP}:${SENTINEL_TLS_PORT})"
+            echo "sentinel announce-port ${SENTINEL_TLS_PORT}" >> ${SENTINEL_CONF}
+        else
+            echo "  announce (${ANNOUNCE_IP}:${SENTINEL_PORT})"
+            echo "sentinel announce-port ${SENTINEL_PORT}" >> ${SENTINEL_CONF}
+        fi
+    }
+
+    redis_update() {
+        echo "Updating redis config.."
+        if [ "$REDIS_TLS_REPLICATION_ENABLED" = true ]; then
+            echo "  we are slave of redis master (${1}:${REDIS_TLS_PORT})"
+            echo "slaveof ${1} ${REDIS_TLS_PORT}" >> "${REDIS_CONF}"
+            echo "slave-announce-port ${REDIS_TLS_PORT}" >> ${REDIS_CONF}
+        else
+            echo "  we are slave of redis master (${1}:${REDIS_PORT})"
+            echo "slaveof ${1} ${REDIS_PORT}" >> "${REDIS_CONF}"
+            echo "slave-announce-port ${REDIS_PORT}" >> ${REDIS_CONF}
+        fi
+        echo "slave-announce-ip ${ANNOUNCE_IP}" >> ${REDIS_CONF}
+    }
+
+    copy_config() {
+        echo "Copying default redis config.."
+        echo "  to '${REDIS_CONF}'"
+        cp /readonly-config/redis.conf "${REDIS_CONF}"
+        echo "Copying default sentinel config.."
+        echo "  to '${SENTINEL_CONF}'"
+        cp /readonly-config/sentinel.conf "${SENTINEL_CONF}"
+    }
+
+    setup_defaults() {
+        echo "Setting up defaults.."
+        echo "  using statefulset index (${INDEX})"
+        if [ "${INDEX}" = "0" ]; then
+            echo "Setting this pod as master for redis and sentinel.."
+            echo "  using announce (${ANNOUNCE_IP})"
+            redis_update "${ANNOUNCE_IP}"
+            sentinel_update "${ANNOUNCE_IP}"
+            echo "  make sure ${ANNOUNCE_IP} is not a slave (slaveof no one)"
+            sed -i "s/^.*slaveof.*//" "${REDIS_CONF}"
+        else
+            if [ "$RESOLVE_HOSTNAMES" = true ]; then
+                echo "Getting redis master hostname.."
+                echo "  blindly assuming (${SERVICE}-announce-0.${NAMESPACE}.svc) is master"
+                DEFAULT_MASTER="${SERVICE}-announce-0.${NAMESPACE}.svc"
+                echo "  identified redis (may be redis master) hostname (${DEFAULT_MASTER})"
+            else
+                echo "Getting redis master ip.."
+                echo "  blindly assuming (${SERVICE}-announce-0) or (${SERVICE}-server-0) are master"
+                DEFAULT_MASTER="$(getent_hosts 0 | awk '{ print $1 }')"
+                if [ -z "${DEFAULT_MASTER}" ]; then
+                    echo "Error: Unable to resolve redis master (getent hosts)."
+                    exit 1
+                fi
+                echo "  identified redis (may be redis master) ip (${DEFAULT_MASTER})"
+            fi
+            echo "Setting default slave config for redis and sentinel.."
+            echo "  using master address (${DEFAULT_MASTER})"
+            redis_update "${DEFAULT_MASTER}"
+            sentinel_update "${DEFAULT_MASTER}"
+        fi
+    }
+
+    redis_ping() {
+    set +e
+        if [ "$REDIS_PORT" -eq 0 ]; then
+            valkey-cli -h "${MASTER}"{{ if .Values.auth }} -a "${AUTH}" --no-auth-warning{{ end }} -p "${REDIS_TLS_PORT}" --tls --cacert /tls-certs/{{ .Values.tls.caCertFile }} {{ if ne (default "yes" .Values.sentinel.authClients) "no"}} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}{{ end }} ping
+        else
+            valkey-cli -h "${MASTER}"{{ if .Values.auth }} -a "${AUTH}" --no-auth-warning{{ end }} -p "${REDIS_PORT}" ping
+        fi
+    set -e
+    }
+
+    redis_ping_retry() {
+        ping=''
+        retry=${1}
+        sleep=3
+        for i in $(seq 1 "${retry}"); do
+            if [ "$(redis_ping)" = "PONG" ]; then
+               ping='PONG'
+               break
+            fi
+            sleep $((sleep + i))
+            MASTER=$(sentinel_get_master)
+        done
+        echo "${ping}"
+    }
+
+    find_master() {
+        echo "Verifying redis master.."
+        if [ "$REDIS_PORT" -eq 0 ]; then
+            echo "  ping (${MASTER}:${REDIS_TLS_PORT})"
+        else
+            echo "  ping (${MASTER}:${REDIS_PORT})"
+        fi
+        if [ "$(redis_ping_retry 3)" != "PONG" ]; then
+            echo "  $(date) Can't ping redis master (${MASTER})"
+            echo "Attempting to force failover (sentinel failover).."
+
+            if [ "$SENTINEL_PORT" -eq 0 ]; then
+                echo "  on sentinel (${SERVICE}:${SENTINEL_TLS_PORT}), sentinel grp (${MASTER_GROUP})"
+                if valkey-cli -h "${SERVICE}" -p "${SENTINEL_TLS_PORT}" {{ if .Values.sentinel.auth }} -a "${SENTINELAUTH}" --no-auth-warning{{ end }} --tls --cacert /tls-certs/{{ .Values.tls.caCertFile }} {{ if ne (default "yes" .Values.sentinel.authClients) "no"}} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}{{ end }} sentinel failover "${MASTER_GROUP}" | grep -q 'NOGOODSLAVE' ; then
+                    echo "  $(date) Failover returned with 'NOGOODSLAVE'"
+                    echo "Setting defaults for this pod.."
+                    setup_defaults
+                    return 0
+                fi
+            else
+                echo "  on sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
+                if valkey-cli -h "${SERVICE}" -p "${SENTINEL_PORT}" {{ if .Values.sentinel.auth }} -a "${SENTINELAUTH}" --no-auth-warning{{ end }} sentinel failover "${MASTER_GROUP}" | grep -q 'NOGOODSLAVE' ; then
+                    echo "  $(date) Failover returned with 'NOGOODSLAVE'"
+                    echo "Setting defaults for this pod.."
+                    setup_defaults
+                    return 0
+                fi
+            fi
+
+            echo "Hold on for 10sec"
+            sleep 10
+            echo "We should get redis master's ip now. Asking (get-master-addr-by-name).."
+            if [ "$SENTINEL_PORT" -eq 0 ]; then
+                echo "  sentinel (${SERVICE}:${SENTINEL_TLS_PORT}), sentinel grp (${MASTER_GROUP})"
+            else
+                echo "  sentinel (${SERVICE}:${SENTINEL_PORT}), sentinel grp (${MASTER_GROUP})"
+            fi
+            MASTER="$(sentinel_get_master)"
+            if [ "${MASTER}" ]; then
+                echo "  $(date) Found redis master (${MASTER})"
+                echo "Updating redis and sentinel config.."
+                sentinel_update "${MASTER}"
+                redis_update "${MASTER}"
+            else
+                echo "$(date) Error: Could not failover, exiting..."
+                exit 1
+            fi
+        else
+            echo "  $(date) Found reachable redis master (${MASTER})"
+            echo "Updating redis and sentinel config.."
+            sentinel_update "${MASTER}"
+            redis_update "${MASTER}"
+        fi
+    }
+
+    redis_ro_update() {
+        echo "Updating read-only redis config.."
+        echo "  redis.conf set 'replica-priority 0'"
+        echo "replica-priority 0" >> ${REDIS_CONF}
+    }
+
+    getent_hosts() {
+        index=${1:-${INDEX}}
+        service="${SERVICE}-announce-${index}"
+        if [ "$RESOLVE_HOSTNAMES" = true ]; then
+            echo "${service}.${NAMESPACE}.svc"
+        else
+            host=$(getent hosts "${service}")
+            echo "${host}"
+        fi
+    }
+
+    identify_announce_ip() {
+        if [ "$ANNOUNCE_HOSTNAMES" = true ]; then
+            echo "Identify announce hostname for this pod.."
+            echo "  using (${SERVICE}-announce-${INDEX}.${NAMESPACE}.svc)"
+            ANNOUNCE_IP="${SERVICE}-announce-${INDEX}.${NAMESPACE}.svc"
+        else
+            echo "Identify announce ip for this pod.."
+            echo "  using (${SERVICE}-announce-${INDEX}) or (${SERVICE}-server-${INDEX})"
+            ANNOUNCE_IP=$(getent_hosts | awk '{ print $1 }')
+        fi
+        echo "  identified announce (${ANNOUNCE_IP})"
+    }
+{{- end }}
+
+{{- define "vars.sh" }}
+    HOSTNAME="$(cat /proc/sys/kernel/hostname)"
+    {{- if .Values.ro_replicas }}
+    RO_REPLICAS="{{ .Values.ro_replicas }}"
+    {{- end }}
+    INDEX="${HOSTNAME##*-}"
+    SENTINEL_PORT={{ .Values.sentinel.port }}
+    ANNOUNCE_IP=''
+    MASTER=''
+    MASTER_GROUP="{{ template "valkey-ha.masterGroupName" . }}"
+    QUORUM="{{ .Values.sentinel.quorum }}"
+    REDIS_CONF=/data/conf/redis.conf
+    REDIS_PORT={{ .Values.redis.port }}
+    REDIS_TLS_PORT={{ .Values.redis.tlsPort }}
+    SENTINEL_CONF=/data/conf/sentinel.conf
+    SENTINEL_TLS_PORT={{ .Values.sentinel.tlsPort }}
+    SERVICE={{ template "valkey-ha.fullname" . }}
+    NAMESPACE="{{ .Release.Namespace }}"
+    SENTINEL_TLS_REPLICATION_ENABLED={{ default false .Values.sentinel.tlsReplication }}
+    REDIS_TLS_REPLICATION_ENABLED={{ default false .Values.redis.tlsReplication }}
+    RESOLVE_HOSTNAMES={{ default false .Values.sentinel.resolveHostnames }}
+    ANNOUNCE_HOSTNAMES={{ default false .Values.sentinel.announceHostnames }}
+{{- end }}
+
+{{- define "config-init.sh" }}
+    echo "$(date) Start..."
+    {{- include "vars.sh" . }}
+
+    set -eu
+
+    {{- include "lib.sh" . }}
+
+    mkdir -p /data/conf/
+
+    echo "Initializing config.."
+    copy_config
+
+    # where is redis master
+    identify_master
+
+    identify_announce_ip
+
+    if [ -z "${ANNOUNCE_IP}" ]; then
+        echo "Error: Could not resolve the announce address for this pod"
+        exit 1
+    elif [ "${MASTER}" ]; then
+        find_master
+    else
+        setup_defaults
+    fi
+
+    {{- if .Values.ro_replicas }}
+    # works only if index is less than 10
+    echo "Verifying redis read-only replica.."
+    echo "  we have RO_REPLICAS='${RO_REPLICAS}' with INDEX='${INDEX}'"
+    if echo "${RO_REPLICAS}" | grep -q "${INDEX}" ; then
+        redis_ro_update
+    fi
+    {{- end }}
+
+    if [ "${AUTH:-}" ]; then
+        echo "Setting redis auth values.."
+        ESCAPED_AUTH=$(echo "${AUTH}" | sed -e 's/[\/&]/\\&/g');
+        sed -i "s/replace-default-auth/${ESCAPED_AUTH}/" "${REDIS_CONF}" "${SENTINEL_CONF}"
+    fi
+
+    if [ "${SENTINELAUTH:-}" ]; then
+        echo "Setting sentinel auth values"
+        ESCAPED_AUTH_SENTINEL=$(echo "$SENTINELAUTH" | sed -e 's/[\/&]/\\&/g');
+        sed -i "s/replace-default-sentinel-auth/${ESCAPED_AUTH_SENTINEL}/" "$SENTINEL_CONF"
+    fi
+
+    echo "$(date) Ready..."
+{{- end }}
+
+{{- define "trigger-failover-if-master.sh" }}
+    {{- if or (eq (int .Values.redis.port) 0) (eq (int .Values.sentinel.port) 0) }}
+    TLS_CLIENT_OPTION="--tls --cacert /tls-certs/{{ .Values.tls.caCertFile }}{{ if ne (default "yes" .Values.sentinel.authClients) "no"}} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}{{end}}"
+    {{- end }}
+    get_redis_role() {
+      is_master=$(
+        valkey-cli \
+        {{- if .Values.auth }}
+          -a "${AUTH}" --no-auth-warning \
+        {{- end }}
+          -h localhost \
+        {{- if (int .Values.redis.port) }}
+          -p {{ .Values.redis.port }} \
+        {{- else }}
+          -p {{ .Values.redis.tlsPort }} ${TLS_CLIENT_OPTION} \
+        {{- end}}
+          info | grep -c 'role:master' || true
+      )
+    }
+    get_redis_role
+    if [[ "$is_master" -eq 1 ]]; then
+      echo "This node is currently master, we trigger a failover."
+      {{- $masterGroupName := include "valkey-ha.masterGroupName" . }}
+      response=$(
+        valkey-cli \
+        {{- if .Values.sentinel.auth }}
+          -a "${SENTINELAUTH}" --no-auth-warning \
+        {{- end }}
+          -h localhost \
+        {{- if (int .Values.sentinel.port) }}
+          -p {{ .Values.sentinel.port }} \
+        {{- else }}
+          -p {{ .Values.sentinel.tlsPort }} ${TLS_CLIENT_OPTION} \
+        {{- end}}
+          SENTINEL failover {{ $masterGroupName }}
+      )
+      if [[ "$response" != "OK" ]] ; then
+        echo "$response"
+        exit 1
+      fi
+      timeout=30
+      while [[ "$is_master" -eq 1 && $timeout -gt 0 ]]; do
+        sleep 1
+        get_redis_role
+        timeout=$((timeout - 1))
+      done
+      echo "Failover successful"
+    fi
+{{- end }}
+
+{{- define "fix-split-brain.sh" }}
+    {{- include "vars.sh" . }}
+
+    ROLE=''
+    REDIS_MASTER=''
+
+    set -eu
+
+    {{- include "lib.sh" . }}
+
+    redis_role() {
+    set +e
+        if [ "$REDIS_PORT" -eq 0 ]; then
+            ROLE=$(valkey-cli {{ if .Values.auth }} -a "${AUTH}" --no-auth-warning{{ end }} -p "${REDIS_TLS_PORT}" --tls --cacert /tls-certs/{{ .Values.tls.caCertFile }} {{ if ne (default "yes" .Values.sentinel.authClients) "no"}} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}{{ end }} info | grep role | sed 's/role://' | sed 's/\r//')
+        else
+            ROLE=$(valkey-cli {{ if .Values.auth }} -a "${AUTH}" --no-auth-warning{{ end }} -p "${REDIS_PORT}" info | grep role | sed 's/role://' | sed 's/\r//')
+        fi
+    set -e
+    }
+
+    identify_redis_master() {
+    set +e
+        if [ "$REDIS_PORT" -eq 0 ]; then
+            REDIS_MASTER=$(valkey-cli {{ if .Values.auth }} -a "${AUTH}" --no-auth-warning{{ end }} -p "${REDIS_TLS_PORT}" --tls --cacert /tls-certs/{{ .Values.tls.caCertFile }} {{ if ne (default "yes" .Values.sentinel.authClients) "no"}} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}{{ end }} info | grep master_host | sed 's/master_host://' | sed 's/\r//')
+        else
+            REDIS_MASTER=$(valkey-cli {{ if .Values.auth }} -a "${AUTH}" --no-auth-warning{{ end }} -p "${REDIS_PORT}" info | grep master_host | sed 's/master_host://' | sed 's/\r//')
+        fi
+    set -e
+    }
+
+    reinit() {
+    set +e
+        sh /readonly-config/init.sh
+
+        if [ "$REDIS_PORT" -eq 0 ]; then
+            echo "shutdown" | valkey-cli {{ if .Values.auth }} -a "${AUTH}" --no-auth-warning{{ end }} -p "${REDIS_TLS_PORT}" --tls --cacert /tls-certs/{{ .Values.tls.caCertFile }} {{ if ne (default "yes" .Values.sentinel.authClients) "no"}} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}{{ end }}
+        else
+            echo "shutdown" | valkey-cli {{ if .Values.auth }} -a "${AUTH}" --no-auth-warning{{ end }} -p "${REDIS_PORT}"
+        fi
+    set -e
+    }
+
+    identify_announce_ip
+
+    while [ -z "${ANNOUNCE_IP}" ]; do
+        echo "Error: Could not resolve the announce address for this pod."
+        sleep 30
+        identify_announce_ip
+    done
+
+    trap "exit 0" TERM
+    while true; do
+        sleep {{ .Values.splitBrainDetection.interval }}
+
+        # where is redis master
+        identify_master
+
+        if [ "$MASTER" = "$ANNOUNCE_IP" ]; then
+            redis_role
+            if [ "$ROLE" != "master" ]; then
+                echo "waiting for redis to become master"
+                sleep {{ .Values.splitBrainDetection.retryInterval }}
+                identify_master
+                redis_role
+                echo "Redis role is $ROLE, expected role is master. No need to reinitialize."
+                if [ "$ROLE" != "master" ]; then
+                    echo "Redis role is $ROLE, expected role is master, reinitializing"
+                    reinit
+                fi
+            fi
+        elif [ "${MASTER}" ]; then
+            identify_redis_master
+            if [ "$REDIS_MASTER" != "$MASTER" ]; then
+                echo "Redis master and local master are not the same. waiting."
+                sleep {{ .Values.splitBrainDetection.retryInterval }}
+                identify_master
+                identify_redis_master
+                echo "Redis master is ${MASTER}, expected master is ${REDIS_MASTER}. No need to reinitialize."
+                if [ "${REDIS_MASTER}" != "${MASTER}" ]; then
+                    echo "Redis master is ${MASTER}, expected master is ${REDIS_MASTER}, reinitializing"
+                    reinit
+                fi
+            fi
+        fi
+    done
+
+{{- end }}
+
+{{- define "config-haproxy.cfg" }}
+{{- if .Values.haproxy.customConfig }}
+{{ tpl .Values.haproxy.customConfig . | indent 4 }}
+{{- else }}
+    defaults REDIS
+      mode tcp
+      timeout connect {{ .Values.haproxy.timeout.connect }}
+      timeout server {{ .Values.haproxy.timeout.server }}
+      timeout client {{ .Values.haproxy.timeout.client }}
+      timeout check {{ .Values.haproxy.timeout.check }}
+      timeout tunnel {{ .Values.haproxy.timeout.tunnel }}
+
+    listen health_check_http_url
+      bind {{ if .Values.haproxy.IPv6.enabled }}[::]{{ end }}:8888  {{ if .Values.haproxy.IPv6.enabled }}v4v6{{ end }}
+      mode http
+      monitor-uri /healthz
+      option      dontlognull
+
+    {{- $root := . }}
+    {{- $fullName := include "valkey-ha.fullname" . }}
+    {{- $replicas := int (toString .Values.replicas) }}
+    {{- $masterGroupName := include "valkey-ha.masterGroupName" . }}
+    {{- range $i := until $replicas }}
+    # Check Sentinel and whether they are nominated master
+    backend check_if_redis_is_master_{{ $i }}
+      mode tcp
+      option tcp-check
+      tcp-check connect
+      {{- if $root.Values.sentinel.auth }}
+      tcp-check send "AUTH ${SENTINELAUTH}"\r\n
+      tcp-check expect string +OK
+      {{- end }}
+      tcp-check send PING\r\n
+      tcp-check expect string +PONG
+      tcp-check send SENTINEL\ get-master-addr-by-name\ {{ $masterGroupName }}\r\n
+      tcp-check expect string REPLACE_ANNOUNCE{{ $i }}
+      tcp-check send QUIT\r\n
+      {{- range $i := until $replicas }}
+      {{- if $.Values.sentinel.resolveHostnames }}
+      server R{{ $i }} {{ $fullName }}-announce-{{ $i }}.{{ $.Release.Namespace }}.svc:26379 check inter {{ $root.Values.haproxy.checkInterval }}
+      {{- else }}
+      server R{{ $i }} {{ $fullName }}-announce-{{ $i }}:26379 check inter {{ $root.Values.haproxy.checkInterval }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
+
+    # decide redis backend to use
+    #master
+    frontend ft_redis_master
+      {{- if .Values.haproxy.tls.enabled }}
+      bind {{ if .Values.haproxy.IPv6.enabled }}[::]{{ end }}:{{ $root.Values.haproxy.containerPort }} ssl crt {{ .Values.haproxy.tls.certMountPath }}{{ .Values.haproxy.tls.keyName }} {{ if .Values.haproxy.IPv6.enabled }}v4v6{{ end }}
+      {{ else }}
+      bind {{ if .Values.haproxy.IPv6.enabled }}[::]{{ end }}:{{ if ne (int $root.Values.redis.port) 0 }}{{ $root.Values.redis.port }}{{ else }}{{ $root.Values.redis.tlsPort }}{{ end }} {{ if .Values.haproxy.IPv6.enabled }}v4v6{{ end }}
+      {{- end }}
+      use_backend bk_redis_master
+    {{- if .Values.haproxy.readOnly.enabled }}
+    #slave
+    frontend ft_redis_slave
+      bind {{ if .Values.haproxy.IPv6.enabled }}[::]{{ end }}:{{ .Values.haproxy.readOnly.port }} {{ if .Values.haproxy.IPv6.enabled }}v4v6{{ end }}
+      use_backend bk_redis_slave
+    {{- end }}
+    # Check all redis servers to see if they think they are master
+    backend bk_redis_master
+      {{- if .Values.haproxy.stickyBalancing }}
+      balance source
+      hash-type consistent
+      {{- end }}
+      mode tcp
+      option tcp-check
+      tcp-check connect
+      {{- if .Values.auth }}
+      tcp-check send "AUTH ${AUTH}"\r\n
+      tcp-check expect string +OK
+      {{- end }}
+      tcp-check send PING\r\n
+      tcp-check expect string +PONG
+      tcp-check send info\ replication\r\n
+      tcp-check expect string role:master
+      tcp-check send QUIT\r\n
+      tcp-check expect string +OK
+      {{- range $i := until $replicas }}
+      use-server R{{ $i }} if { srv_is_up(R{{ $i }}) } { nbsrv(check_if_redis_is_master_{{ $i }}) ge 2 }
+      {{- if $.Values.sentinel.resolveHostnames }}
+      server R{{ $i }} {{ $fullName }}-announce-{{ $i }}.{{ $.Release.Namespace }}.svc:{{ $root.Values.redis.port }} check inter {{ $root.Values.haproxy.checkInterval }} fall {{ $root.Values.haproxy.checkFall }} rise 1
+      {{- else }}
+      server R{{ $i }} {{ $fullName }}-announce-{{ $i }}:{{ $root.Values.redis.port }} check inter {{ $root.Values.haproxy.checkInterval }} fall {{ $root.Values.haproxy.checkFall }} rise 1
+      {{- end }}
+      {{- end }}
+    {{- if .Values.haproxy.readOnly.enabled }}
+    backend bk_redis_slave
+      {{- if .Values.haproxy.stickyBalancing }}
+      balance source
+      hash-type consistent
+      {{- end }}
+      mode tcp
+      option tcp-check
+      tcp-check connect
+      {{- if .Values.auth }}
+      tcp-check send "AUTH ${AUTH}"\r\n
+      tcp-check expect string +OK
+      {{- end }}
+      tcp-check send PING\r\n
+      tcp-check expect string +PONG
+      tcp-check send info\ replication\r\n
+      tcp-check expect  string role:slave
+      tcp-check send QUIT\r\n
+      tcp-check expect string +OK
+      {{- range $i := until $replicas }}
+      {{- if $.Values.sentinel.resolveHostnames }}
+      server R{{ $i }} {{ $fullName }}-announce-{{ $i }}.{{ $.Release.Namespace }}.svc:{{ $root.Values.redis.port }} check inter {{ $root.Values.haproxy.checkInterval }} fall {{ $root.Values.haproxy.checkFall }} rise 1
+      {{- else }}
+      server R{{ $i }} {{ $fullName }}-announce-{{ $i }}:{{ $root.Values.redis.port }} check inter {{ $root.Values.haproxy.checkInterval }} fall {{ $root.Values.haproxy.checkFall }} rise 1
+      {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.haproxy.metrics.enabled }}
+    frontend stats
+      mode http
+      bind {{ if .Values.haproxy.IPv6.enabled }}[::]{{ end }}:{{ .Values.haproxy.metrics.port }} {{ if .Values.haproxy.IPv6.enabled }}v4v6{{ end }}
+      http-request use-service prometheus-exporter if { path {{ .Values.haproxy.metrics.scrapePath }} }
+      stats enable
+      stats uri /stats
+      stats refresh 10s
+    {{- end }}
+{{- if .Values.haproxy.extraConfig }}
+    # Additional configuration
+{{ .Values.haproxy.extraConfig | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+
+{{- define "config-haproxy_init.sh" }}
+    HAPROXY_CONF=/data/haproxy.cfg
+    cp /readonly/haproxy.cfg "$HAPROXY_CONF"
+    {{- $fullName := include "valkey-ha.fullname" . }}
+    {{- $replicas := int (toString .Values.replicas) }}
+    {{- $resolveHostnames := .Values.sentinel.resolveHostnames }}
+    {{- $namespace := .Release.Namespace }}
+    {{- range $i := until $replicas }}
+    {{- if $resolveHostnames }}
+    ANNOUNCE_IP{{ $i }}="{{ $fullName }}-announce-{{ $i }}.{{ $namespace }}.svc"
+    echo "Using hostname for {{ $fullName }}-announce-{{ $i }}.{{ $namespace }}.svc: $ANNOUNCE_IP{{ $i }}"
+    {{- else }}
+    for loop in $(seq 1 10); do
+      getent hosts {{ $fullName }}-announce-{{ $i }} && break
+      echo "Waiting for service {{ $fullName }}-announce-{{ $i }} to be ready ($loop) ..." && sleep 1
+    done
+    ANNOUNCE_IP{{ $i }}=$(getent hosts "{{ $fullName }}-announce-{{ $i }}" | awk '{ print $1 }')
+    if [ -z "$ANNOUNCE_IP{{ $i }}" ]; then
+      echo "Could not resolve the announce address for {{ $fullName }}-announce-{{ $i }}"
+      exit 1
+    fi
+    {{- end }}
+    sed -i "s/REPLACE_ANNOUNCE{{ $i }}/$ANNOUNCE_IP{{ $i }}/" "$HAPROXY_CONF"
+
+    {{- end }}
+{{- end }}
+
+{{- define "redis_liveness.sh" }}
+    {{- if not (ne (int .Values.sentinel.port) 0) }}
+    TLS_CLIENT_OPTION="--tls --cacert /tls-certs/{{ .Values.tls.caCertFile }}{{ if ne (default "yes" .Values.sentinel.authClients) "no"}} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}{{end}}"
+    {{- end }}
+    response=$(
+      valkey-cli \
+      {{- if .Values.auth }}
+        -a "${AUTH}" --no-auth-warning \
+      {{- end }}
+        -h localhost \
+      {{- if ne (int .Values.redis.port) 0 }}
+        -p {{ .Values.redis.port }} \
+      {{- else }}
+        -p {{ .Values.redis.tlsPort }} ${TLS_CLIENT_OPTION} \
+      {{- end}}
+        ping
+    )
+    echo "response=$response"
+    case $response in
+      PONG|LOADING*) ;;
+      *) exit 1 ;;
+    esac
+    exit 0
+{{- end }}
+
+{{- define "redis_readiness.sh" }}
+    {{- if not (ne (int .Values.sentinel.port) 0) }}
+    TLS_CLIENT_OPTION="--tls --cacert /tls-certs/{{ .Values.tls.caCertFile }}{{ if ne (default "yes" .Values.sentinel.authClients) "no"}} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}{{end}}"
+    {{- end }}
+    response=$(
+      valkey-cli \
+      {{- if .Values.auth }}
+        -a "${AUTH}" --no-auth-warning \
+      {{- end }}
+        -h localhost \
+      {{- if ne (int .Values.redis.port) 0 }}
+        -p {{ .Values.redis.port }} \
+      {{- else }}
+        -p {{ .Values.redis.tlsPort }} ${TLS_CLIENT_OPTION} \
+      {{- end}}
+        ping
+    )
+    if [ "$response" != "PONG" ] ; then
+      echo "ping=$response"
+      exit 1
+    fi
+
+    response=$(
+      valkey-cli \
+      {{- if .Values.auth }}
+        -a "${AUTH}" --no-auth-warning \
+      {{- end }}
+        -h localhost \
+      {{- if ne (int .Values.redis.port) 0 }}
+        -p {{ .Values.redis.port }} \
+      {{- else }}
+        -p {{ .Values.redis.tlsPort }} ${TLS_CLIENT_OPTION} \
+      {{- end}}
+        role
+    )
+    role=$( echo "$response" | sed "1!d" )
+    if [ "$role" = "master" ]; then
+      echo "role=$role"
+      exit 0
+    elif [ "$role" = "slave" ]; then
+      repl=$( echo "$response" | sed "4!d" )
+      echo "role=$role; repl=$repl"
+      if [ "$repl" = "connected" ]; then
+        exit 0
+      else
+        exit 1
+      fi
+    else
+      echo "role=$role"
+      exit 1
+    fi
+{{- end }}
+
+{{- define "sentinel_liveness.sh" }}
+    {{- if not (ne (int .Values.sentinel.port) 0) }}
+    TLS_CLIENT_OPTION="--tls --cacert /tls-certs/{{ .Values.tls.caCertFile }}{{ if ne (default "yes" .Values.sentinel.authClients) "no"}} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}{{end}}"
+    {{- end }}
+    response=$(
+      valkey-cli \
+      {{- if .Values.sentinel.auth }}
+        -a "${SENTINELAUTH}" --no-auth-warning \
+      {{- end }}
+        -h localhost \
+      {{- if ne (int .Values.sentinel.port) 0 }}
+        -p {{ .Values.sentinel.port }} \
+      {{- else }}
+        -p {{ .Values.sentinel.tlsPort }} ${TLS_CLIENT_OPTION} \
+      {{- end}}
+        ping
+    )
+    if [ "$response" != "PONG" ]; then
+      echo "$response"
+      exit 1
+    fi
+    echo "response=$response"
+{{- end }}

--- a/charts/valkey-ha/templates/_configs.tpl
+++ b/charts/valkey-ha/templates/_configs.tpl
@@ -160,17 +160,17 @@
     }
 
     redis_update() {
-        echo "Updating redis config.."
+        echo "Updating valkey config.."
         if [ "$REDIS_TLS_REPLICATION_ENABLED" = true ]; then
-            echo "  we are slave of redis master (${1}:${REDIS_TLS_PORT})"
-            echo "slaveof ${1} ${REDIS_TLS_PORT}" >> "${REDIS_CONF}"
-            echo "slave-announce-port ${REDIS_TLS_PORT}" >> ${REDIS_CONF}
+            echo "  we are replica of valkey primary (${1}:${REDIS_TLS_PORT})"
+            echo "replicaof ${1} ${REDIS_TLS_PORT}" >> "${REDIS_CONF}"
+            echo "replica-announce-port ${REDIS_TLS_PORT}" >> ${REDIS_CONF}
         else
-            echo "  we are slave of redis master (${1}:${REDIS_PORT})"
-            echo "slaveof ${1} ${REDIS_PORT}" >> "${REDIS_CONF}"
-            echo "slave-announce-port ${REDIS_PORT}" >> ${REDIS_CONF}
+            echo "  we are replica of valkey primary (${1}:${REDIS_PORT})"
+            echo "replicaof ${1} ${REDIS_PORT}" >> "${REDIS_CONF}"
+            echo "replica-announce-port ${REDIS_PORT}" >> ${REDIS_CONF}
         fi
-        echo "slave-announce-ip ${ANNOUNCE_IP}" >> ${REDIS_CONF}
+        echo "replica-announce-ip ${ANNOUNCE_IP}" >> ${REDIS_CONF}
     }
 
     copy_config() {
@@ -190,8 +190,8 @@
             echo "  using announce (${ANNOUNCE_IP})"
             redis_update "${ANNOUNCE_IP}"
             sentinel_update "${ANNOUNCE_IP}"
-            echo "  make sure ${ANNOUNCE_IP} is not a slave (slaveof no one)"
-            sed -i "s/^.*slaveof.*//" "${REDIS_CONF}"
+            echo "  make sure ${ANNOUNCE_IP} is not a replica (replicaof no one)"
+            sed -i "s/^.*replicaof.*//" "${REDIS_CONF}"
         else
             if [ "$RESOLVE_HOSTNAMES" = true ]; then
                 echo "Getting redis master hostname.."

--- a/charts/valkey-ha/templates/_helpers.tpl
+++ b/charts/valkey-ha/templates/_helpers.tpl
@@ -1,0 +1,154 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "valkey-ha.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "valkey-ha.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Return sysctl image
+*/}}
+{{- define "redis.sysctl.image" -}}
+{{- $registryName :=  default "docker.io" .Values.sysctlImage.registry -}}
+{{- $tag := default "latest" .Values.sysctlImage.tag | toString -}}
+{{- printf "%s/%s:%s" $registryName .Values.sysctlImage.repository $tag -}}
+{{- end -}}
+
+{{- /*
+Credit: @technosophos
+https://github.com/technosophos/common-chart/
+labels.standard prints the standard Helm labels.
+The standard labels are frequently used in metadata.
+*/ -}}
+{{- define "labels.standard" -}}
+app: {{ template "valkey-ha.name" . }}
+heritage: {{ .Release.Service | quote }}
+release: {{ .Release.Name | quote }}
+chart: {{ template "chartref" . }}
+{{- end -}}
+
+{{- /*
+Credit: @technosophos
+https://github.com/technosophos/common-chart/
+chartref prints a chart name and version.
+It does minimal escaping for use in Kubernetes labels.
+Example output:
+  zookeeper-1.2.3
+  wordpress-3.2.1_20170219
+*/ -}}
+{{- define "chartref" -}}
+  {{- replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "valkey-ha.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "valkey-ha.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "valkey-ha.masterGroupName" -}}
+{{- $masterGroupName := tpl ( .Values.redis.masterGroupName | default "") . -}}
+{{- $validMasterGroupName := regexMatch "^[\\w-\\.]+$" $masterGroupName -}}
+{{- if $validMasterGroupName -}}
+{{ $masterGroupName }}
+{{- else -}}
+{{ required "A valid .Values.redis.masterGroupName entry is required (matching ^[\\w-\\.]+$)" ""}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for poddisruptionbudget.
+*/}}
+{{- define "valkey-ha.podDisruptionBudget.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- print "policy/v1" -}}
+{{- else -}}
+{{- print "policy/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* 
+Return true if the detected platform is Openshift
+Usage:
+{{- include "common.compatibility.isOpenshift" . -}}
+*/}}
+{{- define "compatibility.isOpenshift" -}}
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" -}}
+{{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render a compatible securityContext depending on the platform. By default it is maintained as it is. In other platforms like Openshift we remove default user/group values that do not work out of the box with the restricted-v1 SCC
+Usage:
+{{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) -}}
+*/}}
+{{- define "compatibility.renderSecurityContext" -}}
+{{- $adaptedContext := .secContext -}}
+
+{{- if (((.context.Values.global).compatibility).openshift) -}}
+  {{- if or (eq .context.Values.global.compatibility.openshift.adaptSecurityContext "force") (and (eq .context.Values.global.compatibility.openshift.adaptSecurityContext "auto") (include "compatibility.isOpenshift" .context)) -}}
+    {{/* Remove incompatible user/group values that do not work in Openshift out of the box */}}
+    {{- $adaptedContext = omit $adaptedContext "fsGroup" "runAsUser" "runAsGroup" -}}
+    {{- if not .secContext.seLinuxOptions -}}
+    {{/* If it is an empty object, we remove it from the resulting context because it causes validation issues */}}
+    {{- $adaptedContext = omit $adaptedContext "seLinuxOptions" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{/* Remove fields that are disregarded when running the container in privileged mode */}}
+{{- if $adaptedContext.privileged -}}
+  {{- $adaptedContext = omit $adaptedContext "capabilities" "seLinuxOptions" -}}
+{{- end -}}
+{{- omit $adaptedContext "enabled" | toYaml -}}
+{{- end -}}
+
+{{/*
+Defines the redis ports to be used inside network policies
+Usage:
+{{- include "redis-ports" . -}}
+*/}}
+{{- define "redis-ports" -}}
+{{- if ne (int .Values.redis.port) 0 }}
+- port: {{ .Values.redis.port }}
+  protocol: TCP
+{{- end -}}
+{{- if ne (int .Values.sentinel.port) 0 }}
+- port: {{ .Values.sentinel.port }}
+  protocol: TCP
+{{- end -}}
+{{- if ne (int .Values.redis.tlsPort) 0 }}
+- port: {{ .Values.redis.tlsPort }}
+  protocol: TCP
+{{- end -}}
+{{- if ne (int .Values.sentinel.tlsPort) 0 }}
+- port: {{ .Values.sentinel.tlsPort }}
+  protocol: TCP
+{{- end -}}
+{{- end -}}

--- a/charts/valkey-ha/templates/sentinel-auth-secret.yaml
+++ b/charts/valkey-ha/templates/sentinel-auth-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.sentinel.auth (not (tpl ( .Values.sentinel.existingSecret | default "" ) . )) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-sentinel
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+type: Opaque
+data:
+  {{ .Values.sentinel.authKey }}: {{ .Values.sentinel.password | b64enc | quote }}
+{{- end -}}

--- a/charts/valkey-ha/templates/tests/test-valkey-ha-configmap.yaml
+++ b/charts/valkey-ha/templates/tests/test-valkey-ha-configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-configmap-test
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  nodeSelector: {{ toYaml .Values.nodeSelector | nindent 4 }}
+  tolerations: {{ toYaml .Values.tolerations | nindent 4 }}
+  containers:
+  - name: check-init
+    image: {{ .Values.configmapTest.image.repository }}:{{ .Values.configmapTest.image.tag }}
+    args:
+    - --shell=sh
+    - /readonly-config/init.sh
+    volumeMounts:
+    - name: config
+      mountPath: /readonly-config
+      readOnly: true
+    resources: {{ toYaml .Values.configmapTest.resources | nindent 6 }}
+    securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 6 }}
+  {{- if .Values.imagePullSecrets }}
+  imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 4 }}
+  {{- end }}
+  restartPolicy: Never
+  volumes:
+  - name: config
+    configMap:
+      name: {{ template "valkey-ha.fullname" . }}-configmap

--- a/charts/valkey-ha/templates/tests/test-valkey-ha-pod.yaml
+++ b/charts/valkey-ha/templates/tests/test-valkey-ha-pod.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.haproxy.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-service-test
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+  annotations:
+  {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 4 }}
+  {{- end }}
+    "helm.sh/hook": test-success
+spec:
+  nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 4 }}
+  tolerations:
+{{ toYaml .Values.tolerations | indent 4 }}
+  containers:
+  - name: "{{ .Release.Name }}-service-test"
+    image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+    command:
+      - sh
+      - -c
+      - valkey-cli -h {{ template "valkey-ha.fullname" . }}-haproxy -p {{ .Values.redis.port }} info server
+    resources: {{ toYaml .Values.haproxy.tests.resources | nindent 6 }}
+    securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 6 }}
+  {{- if .Values.imagePullSecrets }}
+  imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 4 }}
+  {{- end }}
+  restartPolicy: Never
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-auth-secret.yaml
+++ b/charts/valkey-ha/templates/valkey-auth-secret.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.auth (not (tpl (.Values.existingSecret | default "" ) . )) -}}
+{{ $fullAnnotations := mustMerge .Values.redis.annotations .Values.authSecretAnnotations }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- with $fullAnnotations }}
+  annotations: {{ . | toYaml | nindent 4 }}
+  {{- end }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+type: Opaque
+data:
+  {{ .Values.authKey }}: {{ .Values.redisPassword | b64enc | quote }}
+{{- end -}}

--- a/charts/valkey-ha/templates/valkey-ha-announce-service.yaml
+++ b/charts/valkey-ha/templates/valkey-ha-announce-service.yaml
@@ -1,0 +1,64 @@
+{{- $fullName := include "valkey-ha.fullname" . }}
+{{- $namespace := .Release.Namespace -}}
+{{- $replicas := int (toString .Values.replicas) }}
+{{- $root := . }}
+{{- range $i := until $replicas }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-announce-{{ $i }}
+  namespace: {{ $namespace | quote }}
+  labels:
+{{ include "labels.standard" $root | indent 4 }}
+    {{- range $key, $value := $root.Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  annotations:
+{{- if (semverCompare "<=1.10-0" $.Capabilities.KubeVersion.Version) }}
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+{{- end }}
+  {{- if $root.Values.serviceAnnotations }}
+{{ toYaml $root.Values.serviceAnnotations | indent 4 }}
+  {{- end }}
+spec:
+{{- if (semverCompare ">=1.11-0" $.Capabilities.KubeVersion.Version) }}
+  publishNotReadyAddresses: true
+{{- end }}
+  type: ClusterIP
+  ports:
+  {{- if ne (int $root.Values.redis.port) 0 }}
+  - name: tcp-server
+    port: {{ $root.Values.redis.port }}
+    protocol: TCP
+    targetPort: redis
+  {{- end }}
+  {{- if $root.Values.redis.tlsPort }}
+  - name: server-tls
+    port: {{ $root.Values.redis.tlsPort }}
+    protocol: TCP
+    targetPort: redis-tls
+  {{- end }}
+  {{- if ne (int $root.Values.sentinel.port) 0 }}
+  - name: tcp-sentinel
+    port: {{ $root.Values.sentinel.port }}
+    protocol: TCP
+    targetPort: sentinel
+  {{- end }}
+  {{- if $root.Values.sentinel.tlsPort }}
+  - name: sentinel-tls
+    port: {{ $root.Values.sentinel.tlsPort }}
+    protocol: TCP
+    targetPort: sentinel-tls
+  {{- end }}
+  {{- if $root.Values.exporter.enabled }}
+  - name: http-exporter
+    port: {{ $root.Values.exporter.port }}
+    protocol: TCP
+    targetPort: {{ $root.Values.exporter.portName }}
+  {{- end }}
+  selector:
+    release: {{ $root.Release.Name }}
+    app: {{ include "valkey-ha.name" $root }}
+    "statefulset.kubernetes.io/pod-name": {{ $fullName }}-server-{{ $i }}
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-ha-configmap.yaml
+++ b/charts/valkey-ha/templates/valkey-ha-configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-configmap
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "valkey-ha.fullname" . }}
+    {{- range $key, $value := .Values.configmap.labels }}
+    {{ $key }}: {{ $value | toString }}
+    {{- end }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+data:
+  redis.conf: |
+{{- include "config-redis.conf" . }}
+
+  sentinel.conf: |
+{{- include "config-sentinel.conf" . }}
+
+  init.sh: |
+{{- include "config-init.sh" . }}
+
+  fix-split-brain.sh: |
+{{- include "fix-split-brain.sh" . }}
+
+{{ if .Values.haproxy.enabled }}
+  haproxy.cfg: |
+{{- include "config-haproxy.cfg" . }}
+{{- end }}
+  haproxy_init.sh: |
+{{- include "config-haproxy_init.sh" . }}
+  trigger-failover-if-master.sh: |
+{{- include "trigger-failover-if-master.sh" . }}

--- a/charts/valkey-ha/templates/valkey-ha-exporter-script-configmap.yaml
+++ b/charts/valkey-ha/templates/valkey-ha-exporter-script-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.exporter.script }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-exporter-script-configmap
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+data:
+  script: {{ toYaml .Values.exporter.script | indent 2 }}
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-ha-health-configmap.yaml
+++ b/charts/valkey-ha/templates/valkey-ha-health-configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-health-configmap
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "valkey-ha.fullname" . }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+data:
+  redis_liveness.sh: |
+{{- include "redis_liveness.sh" . }}
+  redis_readiness.sh: |
+{{- include "redis_readiness.sh" . }}
+  sentinel_liveness.sh: |
+{{- include "sentinel_liveness.sh" . }}

--- a/charts/valkey-ha/templates/valkey-ha-network-policy.yaml
+++ b/charts/valkey-ha/templates/valkey-ha-network-policy.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- $root := . }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-network-policy
+  namespace: {{ .Release.Namespace | quote }}
+{{- if .Values.networkPolicy.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.networkPolicy.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+{{- end }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.networkPolicy.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      app: {{ template "valkey-ha.name" . }}
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - to:
+      - podSelector: 
+          matchLabels:
+            release: {{ .Release.Name }}
+            app: {{ template "valkey-ha.name" . }}
+      ports:
+      {{- include "redis-ports" . | nindent 6 }}
+{{-  range $rule := .Values.networkPolicy.egressRules }}
+    - to:
+{{ (tpl (toYaml $rule.selectors) $) | indent 7 }}
+      ports:
+{{ toYaml $rule.ports | indent 7 }}
+{{- end }}
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            release: {{ .Release.Name }}
+            app: {{ template "valkey-ha.name" . }}
+      ports: 
+      {{- include "redis-ports" . | nindent 6 }}
+{{- if .Values.haproxy.enabled }}
+    - from:
+        - podSelector:
+            matchLabels:
+              release: {{ .Release.Name }}
+              app: {{ template "valkey-ha.name" . }}-haproxy
+      ports:
+      {{- include "redis-ports" . | nindent 6 }}
+{{- end }}
+{{-  range $rule := .Values.networkPolicy.ingressRules }}
+    - from:
+{{ (tpl (toYaml $rule.selectors) $) | indent 7 }}
+      ports:
+{{- if $rule.ports }}
+{{ toYaml $rule.ports | indent 7 }}
+{{- else }}
+      {{- include "redis-ports" $root | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-ha-pdb.yaml
+++ b/charts/valkey-ha/templates/valkey-ha-pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: {{ template "valkey-ha.podDisruptionBudget.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-pdb
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      app: {{ template "valkey-ha.name" . }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/charts/valkey-ha/templates/valkey-ha-prometheus-rule.yaml
+++ b/charts/valkey-ha/templates/valkey-ha-prometheus-rule.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}
+  {{- if .Values.prometheusRule.namespace }}
+  namespace: {{ .Values.prometheusRule.namespace }}
+  {{- end }}
+  {{- if .Values.prometheusRule.additionalLabels }}
+  labels: {{- toYaml .Values.prometheusRule.additionalLabels | nindent 4 }}
+  {{- end }}
+spec:
+  groups:
+    - name: {{ template "valkey-ha.fullname" . }}
+      {{- if .Values.prometheusRule.interval }}
+      interval: {{ .Values.prometheusRule.interval }}
+      {{- end }}
+      rules: {{- tpl (toYaml .Values.prometheusRule.rules) . | nindent 8 }}
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-ha-role.yaml
+++ b/charts/valkey-ha/templates/valkey-ha-role.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.serviceAccount.create .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - endpoints
+  verbs:
+    - get
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-ha-rolebinding.yaml
+++ b/charts/valkey-ha/templates/valkey-ha-rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.serviceAccount.create .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "valkey-ha.serviceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "valkey-ha.fullname" . }}
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-ha-secret.yaml
+++ b/charts/valkey-ha/templates/valkey-ha-secret.yaml
@@ -1,0 +1,32 @@
+{{- if not .Values.restore.existingSecret }}
+
+
+{{- $regexRestoreS3 := "^s3://.+|^S3://.+" -}}
+{{- $regexRestoreSSH := "^.+@.+:.+" -}}
+
+{{- if or (regexFind $regexRestoreSSH (toString .Values.restore.ssh.source)) (regexFind $regexRestoreS3 (toString .Values.restore.s3.source)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "valkey-ha.fullname" . }}-secret
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "valkey-ha.fullname" . }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+type: Opaque
+data:
+{{- if regexFind $regexRestoreSSH (toString .Values.restore.ssh.source) }}
+  SSH_KEY: "{{ .Values.restore.ssh.key | b64enc }}"
+{{- end }}
+{{- if regexFind $regexRestoreS3 (toString .Values.restore.s3.source) }}
+  AWS_SECRET_ACCESS_KEY: "{{ .Values.restore.s3.secret_key | b64enc }}"
+  AWS_ACCESS_KEY_ID: "{{ .Values.restore.s3.access_key | b64enc }}"
+{{- end }}
+{{- end }}
+
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-ha-service.yaml
+++ b/charts/valkey-ha/templates/valkey-ha-service.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+{{- if .Values.exporter.enabled }}
+    exporter: enabled
+{{- end }}
+{{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- range $key, $value := .Values.serviceLabels }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+  annotations:
+  {{- if .Values.serviceAnnotations }}
+{{ toYaml .Values.serviceAnnotations | indent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  {{- if ne (int .Values.redis.port) 0 }}
+  - name: tcp-server
+    port: {{ .Values.redis.port }}
+    protocol: TCP
+    targetPort: redis
+  {{- end }}
+  {{- if .Values.redis.tlsPort }}
+  - name: server-tls
+    port: {{ .Values.redis.tlsPort }}
+    protocol: TCP
+    targetPort: redis-tls
+  {{- end }}
+  {{- if ne (int .Values.sentinel.port) 0 }}
+  - name: tcp-sentinel
+    port: {{ .Values.sentinel.port }}
+    protocol: TCP
+    targetPort: sentinel
+  {{- end }}
+  {{- if .Values.sentinel.tlsPort }}
+  - name: sentinel-tls
+    port: {{ .Values.sentinel.tlsPort }}
+    protocol: TCP
+    targetPort: sentinel-tls
+  {{- end }}
+{{- if .Values.exporter.enabled }}
+  - name: http-exporter-port
+    port: {{ .Values.exporter.port }}
+    protocol: TCP
+    targetPort: {{ .Values.exporter.portName }}
+{{- end }}
+  selector:
+    release: {{ .Release.Name }}
+    app: {{ template "valkey-ha.name" . }}

--- a/charts/valkey-ha/templates/valkey-ha-serviceaccount.yaml
+++ b/charts/valkey-ha/templates/valkey-ha-serviceaccount.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "valkey-ha.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "valkey-ha.fullname" . }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- end }}
+{{- if or .Values.auth .Values.sentinel.auth }}
+secrets:
+{{- end }}
+{{- if and (and (.Values.auth) (.Values.sentinel.auth)) (eq (.Values.existingSecret) (.Values.sentinel.existingSecret)) }}
+- name: {{ default (include "valkey-ha.fullname" .) (tpl (.Values.existingSecret | default "" ) . ) }}
+{{- else }}
+{{- if .Values.auth }}
+- name: {{ default (include "valkey-ha.fullname" .) (tpl (.Values.existingSecret | default "" ) . ) }}
+{{- end }}
+{{- if .Values.sentinel.auth }}
+- name: {{ default (printf "%s-sentinel" (include "valkey-ha.fullname" .)) (tpl (.Values.sentinel.existingSecret | default "" ) . ) }}
+{{- end }}
+{{- end }}
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-ha-servicemonitor.yaml
+++ b/charts/valkey-ha/templates/valkey-ha-servicemonitor.yaml
@@ -1,0 +1,47 @@
+{{- if and ( or .Values.exporter.serviceMonitor.disableAPICheck ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ) ( .Values.exporter.serviceMonitor.enabled ) ( .Values.exporter.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}
+  namespace: {{ .Values.exporter.serviceMonitor.namespace | default .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- range $key, $value := .Values.exporter.serviceMonitor.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  endpoints:
+  - targetPort: {{ .Values.exporter.port }}
+{{- if .Values.exporter.serviceMonitor.interval }}
+    interval: {{ .Values.exporter.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.exporter.serviceMonitor.telemetryPath }}
+    path: {{ .Values.exporter.serviceMonitor.telemetryPath }}
+{{- end }}
+{{- if .Values.exporter.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.exporter.serviceMonitor.timeout }}
+{{- end }}
+{{- with .Values.exporter.serviceMonitor.endpointAdditionalProperties }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.exporter.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.exporter.serviceMonitor.metricRelabelings | nindent 6 }}
+{{- end }}
+{{- if .Values.exporter.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.exporter.serviceMonitor.relabelings | nindent 6 }}
+{{- end }}
+  jobLabel: {{ template "valkey-ha.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      app: {{ template "valkey-ha.name" . }}
+      release: {{ .Release.Name }}
+      exporter: enabled
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-ha-statefulset.yaml
+++ b/charts/valkey-ha/templates/valkey-ha-statefulset.yaml
@@ -1,0 +1,666 @@
+{{- $regexRestoreS3 := "^s3://.+|^S3://.+" -}}
+{{- $regexRestoreSSH := "^.+@.+:.+" -}}
+{{- $regexRestoreRedis := "^redis://(?:[A-Za-z0-9_]+(?::[^@]+)?@)?[A-Za-z0-9.-]+(?::\\d{1,5})?(?:/\\d+)?$" -}}
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-server
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{ template "valkey-ha.fullname" . }}: replica
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+{{ include "labels.standard" . | indent 4 }}
+  annotations:
+{{ toYaml .Values.redis.annotations | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      app: {{ template "valkey-ha.name" . }}
+  serviceName: {{ template "valkey-ha.fullname" . }}
+  replicas: {{ .Values.replicas }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  updateStrategy:
+    type: {{ .Values.redis.updateStrategy.type }}
+  {{- if .Values.redis.minReadySeconds }}
+  minReadySeconds: {{ .Values.redis.minReadySeconds }}
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/init-config: {{ print (include "config-redis.conf" .) (include "config-sentinel.conf" .) (include "config-init.sh" .) (include "fix-split-brain.sh" .) (include "redis_liveness.sh" .) (include "redis_readiness.sh" .) (include "sentinel_liveness.sh" .) (include "trigger-failover-if-master.sh" .)| sha256sum }}
+      {{- if .Values.redis.podAnnotations }}
+{{ toYaml .Values.redis.podAnnotations | indent 8 }}
+      {{- end }}
+      {{- if and (.Values.exporter.enabled) (not .Values.exporter.serviceMonitor.enabled) }}
+        prometheus.io/port: "{{ .Values.exporter.port }}"
+        prometheus.io/scrape: "true"
+        prometheus.io/path: {{ .Values.exporter.scrapePath }}
+      {{- end }}
+      labels:
+        release: {{ .Release.Name }}
+        app: {{ template "valkey-ha.name" . }}
+        {{ template "valkey-ha.fullname" . }}: replica
+        {{- range $key, $value := .Values.labels }}
+        {{ $key }}: {{ $value | toString }}
+        {{- end }}
+        {{- range $key, $value := .Values.extraLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    spec:
+      {{- if .Values.redis.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.redis.terminationGracePeriodSeconds }}
+      {{- end }}
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      affinity:
+    {{- if .Values.affinity }}
+    {{- with .Values.affinity }}
+{{ tpl . $ | indent 8 }}
+    {{- end }}
+    {{- else }}
+    {{- if .Values.additionalAffinities }}
+{{ toYaml .Values.additionalAffinities | indent 8 }}
+    {{- end }}
+        podAntiAffinity:
+    {{- if .Values.hardAntiAffinity }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: {{ template "valkey-ha.name" . }}
+                  release: {{ .Release.Name }}
+                  {{ template "valkey-ha.fullname" . }}: replica
+              topologyKey: kubernetes.io/hostname
+    {{- else }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: {{ template "valkey-ha.name" . }}
+                    release: {{ .Release.Name }}
+                    {{ template "valkey-ha.fullname" . }}: replica
+                topologyKey: kubernetes.io/hostname
+    {{- end }}
+    {{- end }}
+    {{- if .Values.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+      - maxSkew: {{ .Values.topologySpreadConstraints.maxSkew | default 1 }}
+        topologyKey: {{ .Values.topologySpreadConstraints.topologyKey | default "topology.kubernetes.io/zone" }}
+        whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable | default "ScheduleAnyway" }}
+        labelSelector:
+          matchLabels:
+            app: {{ template "valkey-ha.name" . }}
+            release: {{ .Release.Name }}
+            {{ template "valkey-ha.fullname" . }}: replica
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.securityContext "context" $) | nindent 8 }}
+      serviceAccountName: {{ template "valkey-ha.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
+      initContainers:
+      {{- if .Values.sysctlImage.enabled }}
+      - name: init-sysctl
+        image: {{ template "redis.sysctl.image" . }}
+        imagePullPolicy: {{ .Values.sysctlImage.pullPolicy }}
+        resources: {{ toYaml .Values.sysctlImage.resources | nindent 10 }}
+        {{- if .Values.sysctlImage.mountHostSys }}
+        volumeMounts:
+        - name: host-sys
+          mountPath: /host-sys
+        {{- end }}
+        command: {{ toYaml .Values.sysctlImage.command | nindent 10 }}
+        securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 10 }}
+      {{- end }}
+{{- if and .Values.hostPath.path .Values.hostPath.chown }}
+      - name: hostpath-chown
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 10 }}
+        resources: {{ toYaml .Values.init.resources | nindent 10 }}
+        command:
+        - chown
+        - "{{ .Values.containerSecurityContext.runAsUser }}"
+        - /data
+        volumeMounts:
+        - name: data
+          mountPath: /data
+{{- end }}
+      - name: config-init
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources: {{ toYaml .Values.init.resources | nindent 10 }}
+        command:
+        - sh
+        args:
+        - /readonly-config/init.sh
+        securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 10 }}
+        env:
+{{- $replicas := int (toString .Values.replicas) -}}
+{{- range $i := until $replicas }}
+        - name: SENTINEL_ID_{{ $i }}
+          value: {{ printf "%s\n%s\nindex: %d" (include "valkey-ha.name" $) ($.Release.Name) $i | sha256sum | trunc 40 }}
+{{- end }}
+{{- if .Values.auth }}
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+            {{- if tpl (.Values.existingSecret | default "" ) . }}
+              name: {{ tpl (.Values.existingSecret | default "" ) . }}
+            {{- else }}
+              name: {{ template "valkey-ha.fullname" . }}
+            {{- end }}
+              key: {{ .Values.authKey }}
+{{- end }}
+{{- if .Values.sentinel.auth }}
+        - name: SENTINELAUTH
+          valueFrom:
+            secretKeyRef:
+            {{- if tpl (.Values.sentinel.existingSecret | default "" ) . }}
+              name: {{ tpl (.Values.sentinel.existingSecret | default "" ) . }}
+            {{- else }}
+              name: {{ template "valkey-ha.fullname" . }}-sentinel
+            {{- end }}
+              key: {{ .Values.sentinel.authKey }}
+{{- end }}
+        volumeMounts:
+        - name: config
+          mountPath: /readonly-config
+          readOnly: true
+        - name: data
+          mountPath: /data
+        {{- if .Values.redis.tlsPort }}
+        - mountPath: /tls-certs
+          name: tls-certs
+        {{- end}}
+{{ if regexFind $regexRestoreS3 (toString .Values.restore.s3.source) }}
+      - name: restore-s3
+        image: s3cmd/s3cmd:latest
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources: {{ toYaml .Values.init.resources | nindent 10 }}
+        command:
+        - sh
+        args:
+        - "-c"
+        - "timeout -t {{ .Values.restore.timeout }} \
+             s3cmd get {{ if .Values.restore.s3.region }}--region {{ .Values.restore.s3.region }} {{ end }}--force '{{ .Values.restore.s3.source }}' /data/dump.rdb_ \
+           && test -s /data/dump.rdb_ \
+           && if test -s /data/dump.rdb; \
+              then cp -v /data/dump.rdb /data/dump.rdb_orig; fi \
+           && mv -v /data/dump.rdb_ /data/dump.rdb"
+        envFrom:
+        - secretRef:
+          {{- if .Values.restore.existingSecret }}
+            name: {{ tpl (.Values.existingSecret | default "" ) . }}
+          {{- else }}
+            name: {{ include "valkey-ha.fullname" . }}-secret
+          {{- end }}
+        volumeMounts:
+        - name: data
+          mountPath: /data
+{{- end }}
+{{ if regexFind $regexRestoreSSH (toString .Values.restore.ssh.source) }}
+      - name: restore-ssh
+        image: lgatica/openssh-client:latest
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources: {{ toYaml .Values.init.resources | nindent 10 }}
+        command:
+        - sh
+        args:
+        - "-c"
+        - "rm -f key && echo -e \"${SSH_KEY}\" >key \
+           && chmod 400 key \
+           && timeout {{ .Values.restore.timeout }} \
+                scp -i key \
+                    -o StrictHostKeyChecking=no \
+                    -o UserKnownHostsFile=/dev/null \
+                    '{{ .Values.restore.ssh.source }}' \
+                    /data/dump.rdb_ \
+           && test -s /data/dump.rdb_ \
+           && if test -s /data/dump.rdb; \
+              then cp -v /data/dump.rdb /data/dump.rdb_orig; fi \
+           && mv -v /data/dump.rdb_ /data/dump.rdb"
+        securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 10 }}
+        envFrom:
+        - secretRef:
+          {{- if .Values.restore.existingSecret }}
+            name: {{ tpl (.Values.existingSecret | default "" ) . }}
+          {{- else }}
+            name: {{ include "valkey-ha.fullname" . }}-secret
+          {{- end }}
+        volumeMounts:
+        - name: data
+          mountPath: /data
+{{- end }}
+{{ if regexFind $regexRestoreRedis (toString .Values.restore.redis.source) }}
+      - name: restore-redis
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources: {{ toYaml .Values.init.resources | nindent 10 }}
+        command:
+        - sh
+        args:
+        - "-c"
+        - "echo $HOSTNAME | grep -q 'ha-server-0' \
+          && nc -w 5 -vz {{ regexReplaceAll  "^redis:\\/\\/(.*)" .Values.restore.redis.source "${1}" }} \
+          && test ! -s /data/dump.rdb \
+          && timeout {{ .Values.restore.timeout }} \
+          valkey-cli -u {{ .Values.restore.redis.source }} --rdb /data/dump.rdb_ \
+          && test -s /data/dump.rdb_ \
+          && if test -s /data/dump.rdb; \
+              then cp -v /data/dump.rdb /data/dump.rdb_orig; fi \
+          && mv -v /data/dump.rdb_ /data/dump.rdb || true"
+        {{- if .Values.restore.existingSecret }}
+        envFrom:
+        - secretRef:
+            name: {{ tpl (.Values.existingSecret | default "" ) . }}
+        {{- end }}
+        volumeMounts:
+        - name: data
+          mountPath: /data
+{{- end }}
+{{- if .Values.extraInitContainers }}
+{{- toYaml .Values.extraInitContainers | nindent 6 }}
+{{- end }}
+      containers:
+      - name: redis
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        {{- if .Values.redis.customCommand }}
+{{ toYaml .Values.redis.customCommand | indent 10 }}
+        {{- else }}
+          - valkey-server
+        {{- end }}
+        args:
+        {{- if .Values.redis.customArgs }}
+{{ toYaml .Values.redis.customArgs | indent 10 }}
+        {{- else }}
+          - /data/conf/redis.conf
+        {{- end }}
+        securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 10 }}
+        {{- if .Values.auth }}
+        env:
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+            {{- if tpl (.Values.existingSecret | default "" ) . }}
+              name: {{ tpl (.Values.existingSecret | default "" ) . }}
+            {{- else }}
+              name: {{ template "valkey-ha.fullname" . }}
+            {{- end }}
+              key: {{ .Values.authKey }}
+        {{- end }}
+        {{- if .Values.redis.envFrom }}
+        envFrom:
+{{ toYaml .Values.redis.envFrom | indent 10 }}
+        {{- end }}
+        {{- if .Values.redis.livenessProbe.enabled }}
+        livenessProbe:
+          initialDelaySeconds: {{ .Values.redis.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.redis.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.redis.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.redis.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.redis.livenessProbe.failureThreshold }}
+          exec:
+            command:
+              - sh
+              - -c
+              - /health/redis_liveness.sh
+        {{- end }}
+        {{- if .Values.redis.readinessProbe.enabled }}
+        readinessProbe:
+          initialDelaySeconds: {{ .Values.redis.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.redis.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.redis.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.redis.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.redis.readinessProbe.failureThreshold }}
+          exec:
+            command:
+              - sh
+              - -c
+              - /health/redis_readiness.sh
+        {{- end }}
+        {{- if .Values.redis.startupProbe.enabled }}
+        startupProbe:
+          initialDelaySeconds: {{ .Values.redis.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.redis.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.redis.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.redis.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.redis.startupProbe.failureThreshold }}
+          exec:
+            command:
+              - sh
+              - -c
+              - /health/redis_readiness.sh
+        {{- end }}
+        resources:
+{{ toYaml .Values.redis.resources | indent 10 }}
+        ports:
+        {{- if ne (int .Values.redis.port) 0 }}
+        - name: redis
+          containerPort: {{ .Values.redis.port }}
+        {{- end }}
+        {{- if .Values.redis.tlsPort }}
+        - name: redis-tls
+          containerPort: {{ .Values.redis.tlsPort }}
+        {{- end }}
+        volumeMounts:
+        - name: config
+          mountPath: /readonly-config
+          readOnly: true
+        - mountPath: /data
+          name: data
+        {{- if .Values.redis.tlsPort }}
+        - mountPath: /tls-certs
+          name: tls-certs
+        {{- end}}
+        - mountPath: /health
+          name: health
+{{- if .Values.redis.extraVolumeMounts }}
+{{- toYaml .Values.redis.extraVolumeMounts | nindent 8 }}
+{{- end }}
+        lifecycle:
+{{ toYaml .Values.redis.lifecycle | indent 10 }}
+      - name: sentinel
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        {{- if .Values.sentinel.customCommand }}
+{{ toYaml .Values.sentinel.customCommand | indent 10 }}
+        {{- else }}
+          - valkey-sentinel
+        {{- end }}
+        args:
+        {{- if .Values.sentinel.customArgs }}
+{{ toYaml .Values.sentinel.customArgs | indent 10 }}
+        {{- else }}
+          - /data/conf/sentinel.conf
+        {{- end }}
+        securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 10 }}
+{{- if or .Values.auth .Values.sentinel.auth}}
+        env:
+  {{- if .Values.auth }}
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+            {{- if tpl (.Values.existingSecret | default "" ) . }}
+              name: {{ tpl (.Values.existingSecret | default "" ) . }}
+            {{- else }}
+              name: {{ template "valkey-ha.fullname" . }}
+            {{- end }}
+              key: {{ .Values.authKey }}
+  {{- end }}
+  {{- if .Values.sentinel.auth }}
+        - name: SENTINELAUTH
+          valueFrom:
+            secretKeyRef:
+            {{- if tpl (.Values.sentinel.existingSecret | default "" ) . }}
+              name: {{ tpl (.Values.sentinel.existingSecret | default "" ) . }}
+            {{- else }}
+              name: {{ template "valkey-ha.fullname" . }}-sentinel
+            {{- end }}
+              key: {{ .Values.sentinel.authKey }}
+  {{- end }}
+{{- end }}
+        {{- if .Values.sentinel.livenessProbe.enabled }}
+        livenessProbe:
+          initialDelaySeconds: {{ .Values.sentinel.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentinel.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentinel.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.sentinel.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.sentinel.livenessProbe.failureThreshold }}
+          exec:
+            command:
+              - sh
+              - -c
+              - /health/sentinel_liveness.sh
+        {{- end }}
+        {{- if .Values.sentinel.readinessProbe.enabled }}
+        readinessProbe:
+          initialDelaySeconds: {{ .Values.sentinel.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentinel.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentinel.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.sentinel.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.sentinel.readinessProbe.failureThreshold }}
+          exec:
+            command:
+              - sh
+              - -c
+              - /health/sentinel_liveness.sh
+        {{- end }}
+        {{- if .Values.sentinel.startupProbe.enabled }}
+        startupProbe:
+          initialDelaySeconds: {{ .Values.sentinel.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.sentinel.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.sentinel.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.sentinel.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.sentinel.startupProbe.failureThreshold }}
+          exec:
+            command:
+              - sh
+              - -c
+              - /health/sentinel_liveness.sh
+        {{- end }}
+        resources:
+{{ toYaml .Values.sentinel.resources | indent 10 }}
+        ports:
+        {{- if ne (int .Values.sentinel.port) 0 }}
+          - name: sentinel
+            containerPort: {{ .Values.sentinel.port }}
+        {{- end }}
+        {{- if .Values.sentinel.tlsPort }}
+          - name: sentinel-tls
+            containerPort: {{ .Values.sentinel.tlsPort }}
+        {{- end }}
+        volumeMounts:
+        - mountPath: /data
+          name: data
+        {{- if .Values.redis.tlsPort }}
+        - mountPath: /tls-certs
+          name: tls-certs
+        {{- end }}
+        - mountPath: /health
+          name: health
+{{- if .Values.sentinel.extraVolumeMounts }}
+{{- toYaml .Values.sentinel.extraVolumeMounts | nindent 8 }}
+{{- end }}
+        lifecycle:
+{{ toYaml .Values.sentinel.lifecycle | indent 10 }}
+
+      - name: split-brain-fix
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        livenessProbe: {{ .Values.splitBrainDetection.livenessProbe | toYaml | nindent 10 }}
+        readinessProbe: {{ .Values.splitBrainDetection.readinessProbe | toYaml | nindent 10 }}
+        resources: {{ toYaml .Values.splitBrainDetection.resources | nindent 10 }}
+        command:
+          - sh
+        args:
+          - /readonly-config/fix-split-brain.sh
+        securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 10 }}
+        env:
+{{- $replicas := int (toString .Values.replicas) -}}
+{{- range $i := until $replicas }}
+        - name: SENTINEL_ID_{{ $i }}
+          value: {{ printf "%s\n%s\nindex: %d" (include "valkey-ha.name" $) ($.Release.Name) $i | sha256sum | trunc 40 }}
+{{- end }}
+{{- if .Values.auth }}
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+            {{- if tpl (.Values.existingSecret | default "" ) . }}
+              name: {{ tpl (.Values.existingSecret | default "" ) . }}
+            {{- else }}
+              name: {{ template "valkey-ha.fullname" . }}
+            {{- end }}
+              key: {{ .Values.authKey }}
+{{- end }}
+{{- if .Values.sentinel.auth }}
+        - name: SENTINELAUTH
+          valueFrom:
+            secretKeyRef:
+            {{- if tpl (.Values.sentinel.existingSecret | default "" ) . }}
+              name: {{ tpl (.Values.sentinel.existingSecret | default "" ) . }}
+            {{- else }}
+              name: {{ template "valkey-ha.fullname" . }}-sentinel
+            {{- end }}
+              key: {{ .Values.sentinel.authKey }}
+{{- end }}
+        volumeMounts:
+        - name: config
+          mountPath: /readonly-config
+          readOnly: true
+        - mountPath: /data
+          name: data
+        {{- if .Values.redis.tlsPort }}
+        - mountPath: /tls-certs
+          name: tls-certs
+        {{- end }}
+
+{{- if .Values.exporter.enabled }}
+      - name: redis-exporter
+        image: "{{ .Values.exporter.image }}:{{ .Values.exporter.tag }}"
+        imagePullPolicy: {{ .Values.exporter.pullPolicy }}
+        args:
+        {{- range $key, $value := .Values.exporter.extraArgs }}
+          - --{{ $key }}={{ $value }}
+        {{- end }}
+        securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 10 }}
+        env:
+          - name: REDIS_ADDR
+          {{- if .Values.exporter.sslEnabled }}
+            value: rediss://{{ default "localhost" .Values.exporter.address }}:{{ .Values.redis.tlsPort }}
+          {{- else }}
+            value: redis://{{ default "localhost" .Values.exporter.address }}:{{ .Values.redis.port }}
+          {{- end }}
+        {{- if .Values.auth }}
+          - name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+              {{- if tpl (.Values.existingSecret | default "" ) . }}
+                name: {{ tpl (.Values.existingSecret | default "" ) . }}
+              {{- else }}
+                name: {{ template "valkey-ha.fullname" . }}
+              {{- end }}
+                key: {{ .Values.authKey }}
+        {{- end }}
+        {{- if .Values.exporter.script }}
+          - name: REDIS_EXPORTER_SCRIPT
+            value: /script/script.lua
+        {{- end }}
+        {{- if .Values.exporter.sslEnabled }}
+          - name: REDIS_EXPORTER_TLS_CLIENT_KEY_FILE
+            value: /tls-certs/{{ .Values.tls.keyFile }}
+          - name: REDIS_EXPORTER_TLS_CLIENT_CERT_FILE
+            value: /tls-certs/{{ .Values.tls.certFile }}
+          - name: REDIS_EXPORTER_TLS_CA_CERT_FILE
+            value: /tls-certs/{{ .Values.tls.caCertFile }}
+        {{- end }}
+        livenessProbe:
+{{ toYaml .Values.exporter.livenessProbe | indent 10 }}
+        readinessProbe:
+{{ toYaml .Values.exporter.readinessProbe | indent 10 }}
+        resources:
+{{ toYaml .Values.exporter.resources | indent 10 }}
+        ports:
+          - name: {{ .Values.exporter.portName }}
+            containerPort: {{ .Values.exporter.port }}
+        volumeMounts:
+          {{- if .Values.exporter.script }}
+          - mountPath: /script
+            name: script-mount
+          {{- end }}
+          {{- if .Values.exporter.sslEnabled }}
+          - mountPath: /tls-certs
+            name: tls-certs
+          {{- end }}
+{{- end }}
+{{- if .Values.extraContainers }}
+{{- toYaml .Values.extraContainers | nindent 6 }}
+{{- end -}}
+      {{- with .Values.priorityClassName | default .Values.global.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "valkey-ha.fullname" . }}-configmap
+      {{- if .Values.sysctlImage.mountHostSys }}
+      - name: host-sys
+        hostPath:
+          path: /sys
+      {{- end }}
+      {{- if .Values.exporter.script }}
+      - name: script-mount
+        configMap:
+          name: {{ template "valkey-ha.fullname" . }}-exporter-script-configmap
+          items:
+            - key: script
+              path: script.lua
+      {{- end }}
+      {{- if .Values.redis.tlsPort }}
+      - name: tls-certs
+        secret:
+          {{- if tpl (.Values.tls.secretName | default "" ) . }}
+          secretName: {{ tpl (.Values.tls.secretName | default "" ) . }}
+          {{- else }}
+          secretName: {{ template "valkey-ha.fullname" . }}-tls-secret
+          {{- end }}
+      {{- end }}
+      - name: health
+        configMap:
+          name: {{ template "valkey-ha.fullname" . }}-health-configmap
+          defaultMode: 0755
+{{- if .Values.extraVolumes }}
+{{- toYaml .Values.extraVolumes | nindent 6 }}
+{{- end -}}
+{{- if .Values.persistentVolume.enabled }}
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: data
+      annotations:
+      {{- range $key, $value := .Values.persistentVolume.annotations }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
+      labels: {{- toYaml .Values.persistentVolume.labels | nindent 8 }}
+
+    spec:
+      accessModes:
+      {{- range .Values.persistentVolume.accessModes }}
+        - {{ . | quote }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.persistentVolume.size | quote }}
+    {{- if .Values.persistentVolume.storageClass }}
+    {{- if (eq "-" .Values.persistentVolume.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+    {{- end }}
+{{- end }}
+{{- else if .Values.hostPath.path }}
+      - name: data
+        hostPath:
+          path: {{ tpl .Values.hostPath.path .}}
+{{- else }}
+      - name: data
+        emptyDir:
+{{ toYaml .Values.emptyDir | indent 10 }}
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-haproxy-deployment.yaml
+++ b/charts/valkey-ha/templates/valkey-haproxy-deployment.yaml
@@ -1,0 +1,218 @@
+{{- if .Values.haproxy.enabled }}
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-haproxy
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    component: haproxy
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.haproxy.deploymentAnnotations }}
+  annotations:
+    {{- range $key, $value := .Values.haproxy.deploymentAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- with .Values.haproxy.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  revisionHistoryLimit: 1
+  replicas: {{ .Values.haproxy.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "valkey-ha.name" . }}-haproxy
+      release: {{ .Release.Name }}
+      component: haproxy
+  template:
+    metadata:
+      name: {{ template "valkey-ha.fullname" . }}-haproxy
+      labels:
+        app: {{ template "valkey-ha.name" . }}-haproxy
+        release: {{ .Release.Name }}
+        component: haproxy
+        {{- range $key, $value := .Values.haproxy.labels }}
+        {{ $key }}: {{ $value | toString }}
+        {{- end }}
+        {{- range $key, $value := .Values.extraLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      annotations:
+      {{- if and (.Values.haproxy.metrics.enabled) (not .Values.haproxy.metrics.serviceMonitor.enabled)  }}
+        prometheus.io/port: "{{ .Values.haproxy.metrics.port }}"
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "{{ .Values.haproxy.metrics.scrapePath }}"
+      {{- end }}
+        checksum/config: {{ print (include "config-haproxy.cfg" .) (include "config-haproxy_init.sh" .) | sha256sum }}
+      {{- if .Values.haproxy.podAnnotations }}
+{{ toYaml .Values.haproxy.podAnnotations | indent 8 }}
+      {{- end }}
+    spec:
+      # Needed when using unmodified rbac-setup.yml
+      {{ if .Values.haproxy.serviceAccount.create }}
+      serviceAccountName: {{ template "valkey-ha.serviceAccountName" . }}-haproxy
+      {{- else }}
+      serviceAccountName: {{ .Values.haproxy.serviceAccountName }}
+      {{- end }}
+      securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.haproxy.securityContext "context" $) | nindent 8 }}
+      automountServiceAccountToken: {{ .Values.haproxy.serviceAccount.automountToken }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      affinity:
+    {{- if .Values.haproxy.affinity }}
+    {{- with .Values.haproxy.affinity }}
+{{ tpl . $ | indent 8 }}
+    {{- end }}
+    {{- else }}
+    {{- if .Values.haproxy.additionalAffinities }}
+{{ toYaml .Values.haproxy.additionalAffinities | indent 8 }}
+    {{- end }}
+        podAntiAffinity:
+    {{- if .Values.haproxy.hardAntiAffinity }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: {{ template "valkey-ha.name" . }}-haproxy
+                  release: {{ .Release.Name }}
+                  component: haproxy
+              topologyKey: kubernetes.io/hostname
+    {{- else }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: {{ template "valkey-ha.name" . }}-haproxy
+                    release: {{ .Release.Name }}
+                    component: haproxy
+                topologyKey: kubernetes.io/hostname
+    {{- end }}
+    {{- end }}
+    {{- if .Values.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+      - maxSkew: {{ .Values.topologySpreadConstraints.maxSkew | default 1 }}
+        topologyKey: {{ .Values.topologySpreadConstraints.topologyKey | default "topology.kubernetes.io/zone" }}
+        whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable | default "ScheduleAnyway" }}
+        labelSelector:
+          matchLabels:
+            app: {{ template "valkey-ha.name" . }}-haproxy
+            release: {{ .Release.Name }}
+            component: haproxy
+      {{- end }}
+      initContainers:
+      - name: config-init
+        image: {{ .Values.haproxy.image.repository }}:{{ .Values.haproxy.image.tag }}
+        imagePullPolicy: {{ .Values.haproxy.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.haproxy.init.resources | indent 10 }}
+        command:
+        - sh
+        args:
+        - /readonly/haproxy_init.sh
+        securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.haproxy.containerSecurityContext "context" $) | nindent 10 }}
+        volumeMounts:
+        - name: config-volume
+          mountPath: /readonly
+          readOnly: true
+        - name: data
+          mountPath: /data
+      {{- if .Values.haproxy.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.haproxy.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: haproxy
+        image: {{ .Values.haproxy.image.repository }}:{{ .Values.haproxy.image.tag }}
+        imagePullPolicy: {{ .Values.haproxy.image.pullPolicy }}
+        securityContext: {{- include "compatibility.renderSecurityContext" (dict "secContext" .Values.haproxy.containerSecurityContext "context" $) | nindent 10 }}
+    {{- if or .Values.auth .Values.sentinel.auth}}
+        env:
+      {{- if .Values.auth }}
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+            {{- if tpl (.Values.existingSecret | default "" ) . }}
+              name: {{ tpl (.Values.existingSecret | default "" ) . }}
+            {{- else }}
+              name: {{ template "valkey-ha.fullname" . }}
+            {{- end }}
+              key: {{ .Values.authKey }}
+      {{- end }}
+      {{- if .Values.sentinel.auth }}
+        - name: SENTINELAUTH
+          valueFrom:
+            secretKeyRef:
+            {{- if tpl (.Values.sentinel.existingSecret | default "" ) . }}
+              name: {{ tpl (.Values.sentinel.existingSecret | default "" ) . }}
+            {{- else }}
+              name: {{ template "valkey-ha.fullname" . }}-sentinel
+            {{- end }}
+              key: {{ .Values.sentinel.authKey }}
+      {{- end }}
+    {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: probe
+          initialDelaySeconds: 5
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: probe
+          initialDelaySeconds: 5
+          periodSeconds: 3
+        ports:
+        - name: probe
+          containerPort: 8888
+        - name: redis
+          containerPort: {{ default "6379" .Values.haproxy.containerPort }}
+        {{- if .Values.haproxy.readOnly.enabled }}
+        - name: readonlyport
+          containerPort: {{ default "6380" .Values.haproxy.readOnly.port }}
+        {{- end }}
+        {{- if .Values.haproxy.metrics.enabled }}
+        - name: metrics-port
+          containerPort: {{ default "9101" .Values.haproxy.metrics.port }}
+        {{- end }}
+        {{- range .Values.haproxy.additionalPorts }}
+        - name: {{ .name }}
+          containerPort: {{ .containerPort }}
+        {{- end }}
+        resources:
+{{ toYaml .Values.haproxy.resources | indent 10 }}
+        volumeMounts:
+        - name: data
+          mountPath: /usr/local/etc/haproxy
+        - name: shared-socket
+          mountPath: /run/haproxy
+{{- if .Values.haproxy.tls.enabled }}
+        - name: pemfile
+          mountPath: {{ .Values.haproxy.tls.certMountPath }}
+{{- end }}
+        lifecycle:
+{{ toYaml .Values.haproxy.lifecycle | indent 10 }}
+      {{- with .Values.haproxy.priorityClassName | default .Values.global.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      volumes:
+{{- if .Values.haproxy.tls.enabled }}
+      - name: pemfile
+        secret:
+          secretName: {{ tpl .Values.haproxy.tls.secretName . }}
+{{- end }}
+      - name: config-volume
+        configMap:
+          name: {{ template "valkey-ha.fullname" . }}-configmap
+      - name: shared-socket
+        emptyDir:
+{{ toYaml .Values.haproxy.emptyDir | indent 10 }}
+      - name: data
+        emptyDir:
+{{ toYaml .Values.haproxy.emptyDir | indent 10 }}
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-haproxy-network-policy.yaml
+++ b/charts/valkey-ha/templates/valkey-haproxy-network-policy.yaml
@@ -1,0 +1,66 @@
+{{- if and .Values.haproxy.enabled .Values.haproxy.networkPolicy.enabled }}
+{{- $root := . }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-haproxy-network-policy
+  namespace: {{ .Release.Namespace | quote }}
+  {{- if .Values.haproxy.networkPolicy.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.haproxy.networkPolicy.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  labels:
+    {{- include "labels.standard" . | nindent 4 }}
+    {{- range $key, $value := .Values.haproxy.networkPolicy.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      app: {{ template "valkey-ha.name" . }}-haproxy
+      component: haproxy
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              release: {{ .Release.Name }}
+              app: {{ template "valkey-ha.name" . }}
+      ports:
+      {{- include "redis-ports" . | nindent 6 }}
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{-  range $rule := .Values.haproxy.networkPolicy.egressRules }}
+    - to:
+        {{- (tpl (toYaml $rule.selectors) $) | nindent 8 }}
+      ports:
+        {{- toYaml $rule.ports | nindent 8 }}
+    {{- end }}
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              release: {{ .Release.Name }}
+              app: {{ template "valkey-ha.name" . }}
+      ports:
+      {{- include "redis-ports" . | nindent 8 }}
+    {{-  range $rule := .Values.haproxy.networkPolicy.ingressRules }}
+    - from:
+        {{- (tpl (toYaml $rule.selectors) $) | nindent 8 }}
+      ports:
+        {{- if $rule.ports }}
+        {{- toYaml $rule.ports | nindent 8 }}
+        {{- end }}
+        {{- include "redis-ports" $root | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-haproxy-pdb.yaml
+++ b/charts/valkey-ha/templates/valkey-haproxy-pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.haproxy.podDisruptionBudget -}}
+apiVersion: {{ template "valkey-ha.podDisruptionBudget.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-haproxy-pdb
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      app: {{ template "valkey-ha.name" . }}-haproxy
+      component: haproxy
+{{ toYaml .Values.haproxy.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/charts/valkey-ha/templates/valkey-haproxy-role.yaml
+++ b/charts/valkey-ha/templates/valkey-haproxy-role.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.haproxy.enabled }}
+{{- if and .Values.haproxy.serviceAccount.create .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-haproxy
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    component: haproxy
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - endpoints
+  verbs:
+    - get
+{{- end }}
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-haproxy-rolebinding.yaml
+++ b/charts/valkey-ha/templates/valkey-haproxy-rolebinding.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.haproxy.enabled }}
+{{- if and .Values.haproxy.serviceAccount.create .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-haproxy
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    component: haproxy
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "valkey-ha.serviceAccountName" . }}-haproxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "valkey-ha.fullname" . }}-haproxy
+{{- end }}
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-haproxy-service.yaml
+++ b/charts/valkey-ha/templates/valkey-haproxy-service.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.haproxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-haproxy
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    component: haproxy
+{{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- range $key, $value := .Values.haproxy.service.labels }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+  annotations:
+  {{- if .Values.haproxy.service.annotations }}
+{{ toYaml .Values.haproxy.service.annotations | indent 4 }}
+  {{- end }}
+spec:
+  type: {{ default "ClusterIP" .Values.haproxy.service.type }}
+  {{- if and (eq .Values.haproxy.service.type "LoadBalancer") .Values.haproxy.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.haproxy.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.haproxy.service.type "LoadBalancer") .Values.haproxy.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.haproxy.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if and (eq .Values.haproxy.service.type "LoadBalancer") .Values.haproxy.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.haproxy.service.loadBalancerSourceRanges | nindent 2 }}
+  {{- end }}
+  {{- if .Values.haproxy.service.externalIPs }}
+  externalIPs:
+    {{- range $key, $value := .Values.haproxy.service.externalIPs }}
+    - {{ $value }}
+    {{- end }}
+  {{- end }}
+  ports:
+  - name: tcp-haproxy
+    port: {{ .Values.haproxy.servicePort }}
+    protocol: TCP
+    targetPort: redis
+  {{- if and (eq .Values.haproxy.service.type "NodePort") .Values.haproxy.service.nodePort }}
+    nodePort: {{ .Values.haproxy.service.nodePort }}
+  {{- end }}
+{{- if .Values.haproxy.readOnly.enabled }}
+  - name: tcp-haproxyreadonly
+    port: {{ .Values.haproxy.readOnly.port }}
+    protocol: TCP
+    targetPort: {{ .Values.haproxy.readOnly.port }}
+{{- end }}
+{{- if .Values.haproxy.metrics.enabled }}
+  - name: {{ .Values.haproxy.metrics.portName }}
+    port: {{ .Values.haproxy.metrics.port }}
+    protocol: TCP
+    targetPort: metrics-port
+{{- end }}
+{{- range .Values.haproxy.additionalPorts }}
+  - name: {{ .name }}
+    port: {{ .servicePort | default .containerPort }}
+    protocol: TCP
+    targetPort: {{ .name }}
+{{- end }}
+  selector:
+    release: {{ .Release.Name }}
+    app: {{ template "valkey-ha.name" . }}-haproxy
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-haproxy-serviceaccount.yaml
+++ b/charts/valkey-ha/templates/valkey-haproxy-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.haproxy.serviceAccount.create .Values.haproxy.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "valkey-ha.serviceAccountName" . }}-haproxy
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "valkey-ha.fullname" . }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-haproxy-servicemonitor.yaml
+++ b/charts/valkey-ha/templates/valkey-haproxy-servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{- if and ( or .Values.haproxy.metrics.serviceMonitor.disableAPICheck ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ) ( .Values.haproxy.metrics.serviceMonitor.enabled ) ( .Values.haproxy.metrics.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "valkey-ha.fullname" . }}-haproxy
+  namespace: {{ .Values.haproxy.metrics.serviceMonitor.namespace | default .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- range $key, $value := .Values.haproxy.metrics.serviceMonitor.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  endpoints:
+  - targetPort: {{ .Values.haproxy.metrics.port }}
+{{- if .Values.haproxy.metrics.serviceMonitor.interval }}
+    interval: {{ .Values.haproxy.metrics.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.haproxy.metrics.serviceMonitor.telemetryPath }}
+    path: {{ .Values.haproxy.metrics.serviceMonitor.telemetryPath }}
+{{- end }}
+{{- if .Values.haproxy.metrics.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.haproxy.metrics.serviceMonitor.timeout }}
+{{- end }}
+{{- with .Values.haproxy.metrics.serviceMonitor.endpointAdditionalProperties }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+  jobLabel: {{ template "valkey-ha.fullname" . }}-haproxy
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      app: {{ template "valkey-ha.name" . }}
+      release: {{ .Release.Name }}
+      component: haproxy
+{{- end }}

--- a/charts/valkey-ha/templates/valkey-tls-secret.yaml
+++ b/charts/valkey-ha/templates/valkey-tls-secret.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.redis.tlsPort (not (tpl (.Values.tls.secretName | default "" ) . )) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  metadata:
+  name: {{ template "valkey-ha.fullname" . }}-tls-secret
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+type: Opaque
+data:
+  {{- if .Values.tls.caCertFile }}
+  {{ .Values.tls.caCertFile }}: {{ .Files.Get "certs/ca.crt" | b64enc }}
+  {{- end }}
+  {{- if .Values.tls.certFile }}
+  {{ .Values.tls.certFile }}: {{ .Files.Get "certs/redis.crt" | b64enc }}
+  {{- end }}
+  {{- if .Values.tls.keyFile }}
+  {{ .Values.tls.keyFile }}: {{ .Files.Get "certs/redis.key" | b64enc }}
+  {{- end }}
+  {{- if .Values.tls.dhParamsFile }}
+  {{ .Values.tls.dhParamsFile }}: {{ .Files.Get "certs/redis.dh" | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/valkey-ha/values.schema.json
+++ b/charts/valkey-ha/values.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "valkey-ha values",
+  "description": "Schema for the valkey-ha Helm chart values. Intentionally permissive (additionalProperties allowed) so custom/extra keys are not rejected; it only type-checks the well-known options to catch common misconfiguration at install time.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "replicas": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of valkey primary/replica pods."
+    },
+    "auth": {
+      "type": "boolean",
+      "description": "Enable AUTH (requirepass & masterauth)."
+    },
+    "redisPassword": {
+      "type": ["string", "null"]
+    },
+    "existingSecret": {
+      "type": ["string", "null"]
+    },
+    "authKey": {
+      "type": "string"
+    },
+    "hardAntiAffinity": {
+      "type": "boolean"
+    },
+    "ro_replicas": {
+      "type": ["string", "integer"]
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array"
+    },
+    "redis": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "port": { "type": "integer" },
+        "masterGroupName": { "type": "string" },
+        "config": { "type": "object" },
+        "customConfig": { "type": ["string", "null"] }
+      }
+    },
+    "sentinel": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "port": { "type": "integer" },
+        "auth": { "type": "boolean" },
+        "quorum": { "type": "integer", "minimum": 1 },
+        "config": { "type": "object" }
+      }
+    },
+    "haproxy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 1 },
+        "servicePort": { "type": "integer" },
+        "containerPort": { "type": "integer" }
+      }
+    },
+    "exporter": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "port": { "type": "integer" }
+      }
+    },
+    "persistentVolume": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "size": { "type": "string" },
+        "accessModes": { "type": "array" }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "create": { "type": "boolean" }
+      }
+    },
+    "prometheusRule": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "rules": { "type": "array" }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/charts/valkey-ha/values.yaml
+++ b/charts/valkey-ha/values.yaml
@@ -1019,17 +1019,65 @@ prometheusRule:
   # -- How often rules in the group are evaluated (falls back to `global.evaluation_interval` if not set).
   interval: 10s
   # -- Rules spec template (see https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule).
-  rules: []
-    # Example:
-    # - alert: RedisPodDown
-    #   expr: |
-    #     redis_up{job="{{ include "valkey-ha.fullname" . }}"} == 0
-    #   for: 5m
-    #   labels:
-    #     severity: critical
-    #   annotations:
-    #     description: Redis pod {{ "{{ $labels.pod }}" }} is down
-    #     summary: Redis pod {{ "{{ $labels.pod }}" }} is down
+  # @default -- a set of sensible Valkey alerts (see values.yaml). Requires `exporter.enabled: true` so the metrics exist.
+  # The list is rendered through `tpl`, so `{{ ... }}` expressions are evaluated against the release.
+  rules:
+    - alert: ValkeyInstanceDown
+      expr: |
+        redis_up{job="{{ include "valkey-ha.fullname" . }}"} == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: 'Valkey instance is down ({{ "{{ $labels.pod }}" }})'
+        description: 'The exporter cannot reach Valkey on {{ "{{ $labels.pod }}" }} (job {{ "{{ $labels.job }}" }}) for more than 5 minutes.'
+    - alert: ValkeyNoPrimary
+      expr: |
+        count(redis_instance_info{job="{{ include "valkey-ha.fullname" . }}",role="master"}) == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: 'Valkey has no primary'
+        description: 'No Valkey instance reports role=master for job {{ "{{ $labels.job }}" }}; a Sentinel failover may be in progress or stuck.'
+    - alert: ValkeyMultiplePrimaries
+      expr: |
+        count(redis_instance_info{job="{{ include "valkey-ha.fullname" . }}",role="master"}) > 1
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: 'Valkey reports multiple primaries (possible split brain)'
+        description: 'More than one Valkey instance reports role=master for job {{ "{{ $labels.job }}" }}.'
+    - alert: ValkeyMissingReplicas
+      expr: |
+        min(redis_connected_slaves{job="{{ include "valkey-ha.fullname" . }}"}) < {{ sub (int .Values.replicas) 1 }}
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: 'Valkey primary is missing replicas'
+        description: 'The Valkey primary has fewer than {{ sub (int .Values.replicas) 1 }} connected replicas for job {{ "{{ $labels.job }}" }}.'
+    - alert: ValkeyHighMemoryUsage
+      expr: |
+        redis_memory_max_bytes{job="{{ include "valkey-ha.fullname" . }}"} > 0
+        and
+        (redis_memory_used_bytes{job="{{ include "valkey-ha.fullname" . }}"} / redis_memory_max_bytes{job="{{ include "valkey-ha.fullname" . }}"}) > 0.9
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: 'Valkey memory usage above 90% ({{ "{{ $labels.pod }}" }})'
+        description: 'Valkey {{ "{{ $labels.pod }}" }} is using more than 90% of its configured maxmemory.'
+    - alert: ValkeyRejectedConnections
+      expr: |
+        increase(redis_rejected_connections_total{job="{{ include "valkey-ha.fullname" . }}"}[5m]) > 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: 'Valkey is rejecting connections ({{ "{{ $labels.pod }}" }})'
+        description: 'Valkey {{ "{{ $labels.pod }}" }} rejected one or more connections in the last 5 minutes; check the `maxclients` limit.'
 
 # -- Extra init containers to include in StatefulSet
 extraInitContainers: []

--- a/charts/valkey-ha/values.yaml
+++ b/charts/valkey-ha/values.yaml
@@ -1,0 +1,1109 @@
+## Globally shared configuration
+global:
+  # -- Default priority class for all components
+  priorityClassName: ""
+  # -- Openshift compatibility options
+  compatibility:
+    openshift:
+      adaptSecurityContext: auto
+
+## -- Image information for Valkey HA
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+image:
+  # -- Valkey image repository
+  repository: valkey/valkey
+  # -- Valkey image tag
+  tag: 8.1.8-alpine
+  # -- Valkey image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Full name of the Valkey HA Resources
+fullnameOverride: ""
+
+# -- Name override for Valkey HA resources
+nameOverride: ""
+
+## Reference to one or more secrets to be used when pulling images
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+## This imagePullSecrets is only for redis images
+##
+# -- Reference to one or more secrets to be used when pulling redis images
+imagePullSecrets: []
+# - name: "image-pull-secret"
+
+# -- Number of redis master/slave
+replicas: 3
+
+## Customize the statefulset pod management policy:
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+# -- The statefulset pod management policy
+podManagementPolicy: OrderedReady
+
+## read-only replicas
+## indexed slaves get never promoted to be master
+## index starts with 0 - which is master on init
+## i.e. "8,9" means 8th and 9th slave will be replica with replica-priority=0
+## see also: https://redis.io/topics/sentinel
+# -- Comma separated list of slaves which never get promoted to be master.
+# Count starts with 0. Allowed values 1-9. i.e. 3,4 - 3th and 4th redis slave never make it to be master, where master is index 0.
+ro_replicas: ""
+
+# -- Kubernetes priorityClass name for the valkey-ha-server pod
+priorityClassName: ""
+
+# -- Custom labels for the redis pod
+labels: {}
+
+# -- Custom labels for redis service
+serviceLabels: {}
+
+## Custom labels for the redis configmap
+configmap:
+  # -- Custom labels for the redis configmap
+  labels: {}
+
+## ConfigMap Test Parameters
+configmapTest:
+  # -- Image for valkey-ha-configmap-test hook
+  image:
+    # -- Repository of the configmap shellcheck test image.
+    repository: koalaman/shellcheck
+    # -- Tag of the configmap shellcheck test image.
+    tag: v0.10.0
+  # -- Resources for the ConfigMap test pod
+  resources: {}
+
+## Pods Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+serviceAccount:
+  # -- Specifies whether a ServiceAccount should be created
+  create: true
+  # -- The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the valkey-ha.fullname template
+  name: ""
+  # -- opt in/out of automounting API credentials into container.
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  automountToken: false
+  # -- Annotations to be added to the service account for the redis statefulset
+  annotations: {}
+
+## Enables a HA Proxy for better LoadBalancing / Sentinel Master support. Automatically proxies to Redis master.
+## Recommend for externally exposed Redis clusters.
+## ref: https://cbonte.github.io/haproxy-dconv/1.9/intro.html
+haproxy:
+  # -- Enabled HAProxy LoadBalancing/Proxy
+  enabled: false
+  # -- Modify HAProxy service port
+  servicePort: 6379
+  # -- Modify HAProxy deployment container port
+  containerPort: 6379
+  # -- Enable TLS termination on HAproxy, This will create a volume mount
+  tls:
+    # -- If "true" this will enable TLS termination on haproxy
+    enabled: false
+    # -- Secret containing the .pem file
+    # Supports templates like "{{ .Release.Name }}-haproxy-tls"
+    secretName: ""
+    # -- Key file name
+    keyName:
+    # -- Path to mount the secret that contains the certificates. haproxy
+    certMountPath: /tmp/
+  # -- Enable read-only redis-slaves
+  readOnly:
+    # -- Enable if you want a dedicated port in haproxy for redis-slaves
+    enabled: false
+    # -- Port for the read-only redis-slaves
+    port: 6380
+  # -- Additional ports to expose on HAProxy service and deployment
+  # Each port should have a name, containerPort, and optionally servicePort (defaults to containerPort)
+  additionalPorts: []
+  # Example:
+  # additionalPorts:
+  #   - name: custom-port
+  #     containerPort: 8080
+  #     servicePort: 8080
+  #   - name: another-port
+  #     containerPort: 9090
+  # -- Number of HAProxy instances
+  replicas: 3
+  # -- Deployment strategy for the haproxy deployment
+  deploymentStrategy:
+    type: RollingUpdate
+    # rollingUpdate:
+    #   maxSurge: 25%
+    #   maxUnavailable: 25%
+  image:
+    # -- HAProxy Image Repository
+    repository: public.ecr.aws/docker/library/haproxy
+    # -- HAProxy Image Tag
+    tag: 3.0.8-alpine
+    # -- HAProxy Image PullPolicy
+    pullPolicy: IfNotPresent
+
+  # -- Custom labels for the haproxy pod
+  labels: {}
+
+  # -- Reference to one or more secrets to be used when pulling images
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  imagePullSecrets: []
+  # - name: "image-pull-secret"
+
+  # -- HAProxy template annotations
+  annotations: {}
+
+  # -- HAProxy deployment annotations
+  deploymentAnnotations: {}
+
+  # -- Annotations to be added to the HAProxy deployment pods
+  podAnnotations: {}
+
+  # -- HAProxy resources
+  resources: {}
+
+  # -- Configuration of `emptyDir`
+  emptyDir: {}
+
+  # -- Pod Disruption Budget
+  # ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  podDisruptionBudget: {}
+    # Use only one of the two
+    # maxUnavailable: 1
+    # minAvailable: 1
+
+  ## Enable sticky sessions to Redis nodes via HAProxy
+  ## Very useful for long-living connections as in case of Sentry for example
+  # -- HAProxy sticky load balancing to Redis nodes. Helps with connections shutdown.
+  stickyBalancing: false
+  # -- Kubernetes priorityClass name for the haproxy pod
+  priorityClassName: ""
+
+  ## Service for HAProxy
+  service:
+    # -- HAProxy service type "ClusterIP", "LoadBalancer" or "NodePort"
+    type: ClusterIP
+    # -- (int) HAProxy service nodePort value (haproxy.service.type must be NodePort)
+    nodePort: ~
+    # -- HAProxy service loadbalancer IP
+    loadBalancerIP:
+    # -- (string) HAProxy service externalTrafficPolicy value (haproxy.service.type must be LoadBalancer)
+    externalTrafficPolicy: ~
+    # -- HAProxy external IPs
+    externalIPs: {}
+    # -- HAProxy service labels
+    labels: {}
+    # -- HAProxy service annotations
+    annotations: null
+
+    # -- List of CIDR's allowed to connect to LoadBalancer
+    loadBalancerSourceRanges: []
+
+  # -- HAProxy serviceAccountName
+  serviceAccountName: redis-sa
+  serviceAccount:
+    # -- Specifies whether a ServiceAccount should be created
+    create: true
+    automountToken: true
+
+  ## Official HAProxy embedded prometheus metrics settings.
+  ## Ref: https://github.com/haproxy/haproxy/tree/master/contrib/prometheus-exporter
+  ##
+  metrics:
+    # -- HAProxy enable prometheus metric scraping
+    enabled: false
+    # -- HAProxy prometheus metrics scraping port
+    port: 9101
+    # -- HAProxy metrics scraping port name
+    portName: http-exporter-port
+    # -- HAProxy prometheus metrics scraping path
+    scrapePath: /metrics
+
+    serviceMonitor:
+      # -- When set true then use a ServiceMonitor to configure scraping
+      enabled: false
+      # -- Set the namespace the ServiceMonitor should be deployed
+      # @default -- `.Release.Namespace`
+      namespace: ""
+      # -- Set how frequently Prometheus should scrape (default is 30s)
+      interval: ""
+      # -- Set path to redis-exporter telemtery-path (default is /metrics)
+      telemetryPath: ""
+      # -- Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+      labels: {}
+      # -- Set timeout for scrape (default is 10s)
+      timeout: ""
+      # -- Set additional properties for the ServiceMonitor endpoints such as relabeling, scrapeTimeout, tlsConfig, and more.
+      endpointAdditionalProperties: {}
+      # -- Disable API Check on ServiceMonitor
+      disableAPICheck: false
+  init:
+    # -- Extra init resources
+    resources: {}
+  timeout:
+    # -- haproxy.cfg `timeout connect` setting
+    connect: 4s
+    # -- haproxy.cfg `timeout server` setting
+    server: 330s
+    # -- haproxy.cfg `timeout client` setting
+    client: 330s
+    # -- haproxy.cfg `timeout check` setting
+    check: 2s
+    # -- haproxy.cfg `timeout tunnel` setting
+    tunnel: 1h
+  # -- haproxy.cfg `check inter` setting
+  checkInterval: 1s
+  # -- haproxy.cfg `check fall` setting
+  checkFall: 1
+
+  # -- Security context to be added to the HAProxy deployment.
+  securityContext:
+    runAsUser: 99
+    fsGroup: 99
+    runAsNonRoot: true
+
+  # -- Security context to be added to the HAProxy containers.
+  containerSecurityContext:
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+      - ALL
+
+  # -- Whether the haproxy pods should be forced to run on separate nodes.
+  hardAntiAffinity: true
+
+  # -- Additional affinities to add to the haproxy pods.
+  additionalAffinities: {}
+
+  # -- Override all other affinity settings for the haproxy pods with a string.
+  affinity: |
+
+  ## Custom config-haproxy.cfg files used to override default settings. If this file is
+  ## specified then the config-haproxy.cfg above will be ignored.
+  # -- (string) Allows for custom config-haproxy.cfg file to be applied. If this is used then default config will be overwriten
+  customConfig: ~
+  # customConfig: |-
+    # Define configuration here
+
+  ## Place any additional configuration section to add to the default config-haproxy.cfg
+  # -- (string) Allows to place any additional configuration section to add to the default config-haproxy.cfg
+  extraConfig: ~
+  # extraConfig: |-
+    # Define configuration here
+
+  # -- Container lifecycle hooks.
+  # Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  lifecycle: {}
+
+  ## HAProxy test related options
+  tests:
+    # -- Pod resources for the tests against HAProxy.
+    resources: {}
+
+  ## Enable HAProxy parameters to bind and consume IPv6 addresses. Enabled by default.
+  IPv6:
+    # -- Enable HAProxy parameters to bind and consume IPv6 addresses. Enabled by default.
+    enabled: true
+
+  networkPolicy:
+    # -- whether NetworkPolicy for Haproxy should be created
+    enabled: false
+    # -- Annotations for Haproxy NetworkPolicy
+    annotations: {}
+    # -- Labels for Haproxy NetworkPolicy
+    labels: {}
+    # -- user defined ingress rules that Haproxy should permit into.
+    # uses the format defined in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+    ingressRules: []
+      # - selectors:
+      #   - namespaceSelector:
+      #       matchLabels:
+      #         name: my-valkey-client-namespace
+      #     podSelector:
+      #       matchLabels:
+      #         application: valkey-client
+      ## if ports is not defined then it defaults to the ports defined for enabled services (redis, sentinel)
+      #   ports:
+      #     - port: 6379
+      #       protocol: TCP
+      #     - port: 26379
+      #       protocol: TCP
+
+    # -- user can define egress rules too, uses the same structure as ingressRules
+    egressRules: []
+
+## Role Based Access
+## Ref: https://kubernetes.io/docs/admin/authorization/rbac/
+##
+rbac:
+  # -- Create and use RBAC resources
+  create: true
+
+# NOT RECOMMENDED: Additional container in which you can execute arbitrary commands to update sysctl parameters
+# You can now use securityContext.sysctls to leverage this capability
+# Ref: https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/
+##
+sysctlImage:
+  # -- Enable an init container to modify Kernel settings
+  enabled: false
+  # -- sysctlImage command to execute
+  command: []
+  # -- sysctlImage Init container registry
+  registry: public.ecr.aws/docker/library
+  # -- sysctlImage Init container name
+  repository: busybox
+  # -- sysctlImage Init container tag
+  tag: 1.34.1
+  # -- sysctlImage Init container pull policy
+  pullPolicy: Always
+  # -- Mount the host `/sys` folder to `/host-sys`
+  mountHostSys: false
+  # -- sysctlImage resources
+  resources: {}
+
+# -- Use an alternate scheduler, e.g. "stork".
+# ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+schedulerName: ""
+
+## Redis specific configuration options
+redis:
+  # -- Port to access the redis service
+  port: 6379
+  # -- Redis convention for naming the cluster group: must match `^[\\w-\\.]+$` and can be templated
+  masterGroupName: "mymaster"       # must match ^[\\w-\\.]+$) and can be templated
+
+  # -- Allows overriding the redis container command
+  customCommand: []
+  # - bash
+
+  # -- Allows overriding the redis container arguments
+  customArgs: []
+  # - "custom-startup.sh"
+
+  # -- Load environment variables from ConfigMap/Secret
+  envFrom: []
+  # - secretRef:
+  #     name: add-env-secret
+
+  # -- Configure the 'minReadySeconds' parameter to StatefulSet
+  # ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minreadyseconds
+  minReadySeconds: 0
+
+  ## Configures redis with tls-port parameter
+  # -- (int) TLS Port to access the redis service
+  tlsPort: ~
+  # tlsPort: 6385
+
+  # -- (bool) Configures redis with tls-replication parameter, if true sets "tls-replication yes" in redis.conf
+  tlsReplication: ~
+
+  # -- It is possible to disable client side certificates authentication when "authClients" is set to "no"
+  authClients: ""
+  # authClients: "no"
+
+  # -- Increase terminationGracePeriodSeconds to allow writing large RDB snapshots. (k8s default is 30s)
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination-forced
+  terminationGracePeriodSeconds: 60
+
+  # -- Liveness probe parameters for redis container
+  livenessProbe:
+    # -- Enable the Liveness Probe
+    enabled: true
+    # -- Initial delay in seconds for liveness probe
+    initialDelaySeconds: 30
+    # -- Period in seconds after which liveness probe will be repeated
+    periodSeconds: 15
+    # -- Timeout seconds for liveness probe
+    timeoutSeconds: 15
+    # -- Success threshold for liveness probe
+    successThreshold: 1
+    # -- Failure threshold for liveness probe
+    failureThreshold: 5
+
+  # -- Readiness probe parameters for redis container
+  readinessProbe:
+    # -- Enable the Readiness Probe
+    enabled: true
+    # -- Initial delay in seconds for readiness probe
+    initialDelaySeconds: 30
+    # -- Period in seconds after which readiness probe will be repeated
+    periodSeconds: 15
+    # -- Timeout seconds for readiness probe
+    timeoutSeconds: 15
+    # -- Success threshold for readiness probe
+    successThreshold: 1
+    # -- Failure threshold for readiness probe
+    failureThreshold: 5
+
+  # -- Startup probe parameters for redis container
+  startupProbe:
+    # -- Enable Startup Probe
+    enabled: true
+    # -- Initial delay in seconds for startup probe
+    initialDelaySeconds: 30
+    # -- Period in seconds after which startup probe will be repeated
+    periodSeconds: 15
+    # -- Timeout seconds for startup probe
+    timeoutSeconds: 15
+    # -- Success threshold for startup probe
+    successThreshold: 1
+    # -- Failure threshold for startup probe
+    failureThreshold: 5
+
+  # -- Array with commands to disable
+  disableCommands:
+    - FLUSHDB
+    - FLUSHALL
+
+  # -- Any valid redis config options in this section will be applied to each server, For multi-value configs use list instead of string (for example loadmodule) (see below)
+  # @default -- see values.yaml
+  config:
+    ## -- Additional redis conf options can be added below
+    ## -- For all available options see http://download.redis.io/redis-stable/redis.conf
+    min-replicas-to-write: 1
+    # -- Value in seconds
+    min-replicas-max-lag: 5
+    # -- Max memory to use for each redis instance. Default is unlimited.
+    maxmemory: "0"
+    # -- Max memory policy to use for each redis instance. Default is volatile-lru.
+    maxmemory-policy: "volatile-lru"
+    # -- Determines if scheduled RDB backups are created. Default is false.
+    # -- Please note that local (on-disk) RDBs will still be created when re-syncing with a new slave. The only way to prevent this is to enable diskless replication.
+    save: "900 1"
+    # -- When enabled, directly sends the RDB over the wire to slaves, without using the disk as intermediate storage. Default is false.
+    repl-diskless-sync: "yes"
+    rdbcompression: "yes"
+    rdbchecksum: "yes"
+
+  # -- (string) Allows for custom redis.conf files to be applied. If this is used then `redis.config` is ignored
+  customConfig: ~
+  # customConfig: |-
+    # Define configuration here
+
+  # -- CPU/Memory for master/slave nodes resource requests/limits
+  resources: {}
+  #  requests:
+  #    memory: 200Mi
+  #    cpu: 100m
+  #  limits:
+  #    memory: 700Mi
+
+  # -- Container Lifecycle Hooks for redis container
+  # Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  # @default -- see values.yaml
+  lifecycle:
+    preStop:
+      exec:
+        command: ["/bin/sh", "/readonly-config/trigger-failover-if-master.sh"]
+
+  # -- Annotations for the redis statefulset
+  annotations: {}
+
+  # -- Annotations to be added to the redis statefulset pods
+  podAnnotations: {}
+
+  # -- Update strategy for Redis StatefulSet
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  updateStrategy:
+    type: RollingUpdate
+
+  # -- additional volumeMounts for Redis container
+  extraVolumeMounts: []
+  #  - name: empty
+  #    mountPath: /empty
+
+## Sentinel specific configuration options
+sentinel:
+  # -- Port to access the sentinel service
+  port: 26379
+
+  ## Configure the 'bind' directive to bind to a list of network interfaces
+  bind: ~
+  # bind: 0.0.0.0
+
+  ## Configures sentinel with tls-port parameter
+  # -- (int) TLS Port to access the sentinel service
+  tlsPort: ~
+  # tlsPort: 26385
+
+  # -- (bool) Configures sentinel with tls-replication parameter, if true sets "tls-replication yes" in sentinel.conf
+  tlsReplication: ~
+  # tlsReplication: true
+
+  # -- It is possible to disable client side certificates authentication when "authClients" is set to "no"
+  authClients: ""
+  # authClients: "no"
+
+  ## Configures sentinel with AUTH (requirepass params)
+  # -- Enables or disables sentinel AUTH (Requires `sentinel.password` to be set)
+  auth: false
+
+  # -- (string) A password that configures a `requirepass` in the conf parameters (Requires `sentinel.auth: enabled`)
+  password: ~
+  # password: password
+
+  # -- (bool) Configures sentinel with resolve-hostnames parameter, if true sets "resolve-hostnames yes" in sentinel.conf
+  resolveHostnames: ~
+  # resolveHostnames: true
+
+  # -- (bool) Configures sentinel with announce-hostnames parameter, if true sets "announce-hostnames yes" in sentinel.conf
+  announceHostnames: ~
+  # announceHostnames: true
+
+  # -- An existing secret containing a key defined by `sentinel.authKey` that configures `requirepass`
+  # in the conf parameters (Requires `sentinel.auth: enabled`, cannot be used in conjunction with `.Values.sentinel.password`)
+  # Supports templates like "{{ .Release.Name }}-sentinel-creds"
+  existingSecret: ""
+
+  ## Defines the key holding the sentinel password in existing secret.
+  # -- The key holding the sentinel password in an existing secret.
+  authKey: sentinel-password
+
+  customCommand: []
+  customArgs: []
+
+  # liveness probe parameters for sentinel container
+  livenessProbe:
+    enabled: true
+    # -- Initial delay in seconds for liveness probe
+    initialDelaySeconds: 30
+    # -- Period in seconds after which liveness probe will be repeated
+    periodSeconds: 15
+    # -- Timeout seconds for liveness probe
+    timeoutSeconds: 15
+    # -- Success threshold for liveness probe
+    successThreshold: 1
+    # -- Failure threshold for liveness probe
+    failureThreshold: 5
+
+  # readiness probe parameters for sentinel container
+  readinessProbe:
+    enabled: true
+    # -- Initial delay in seconds for readiness probe
+    initialDelaySeconds: 30
+    # -- Period in seconds after which readiness probe will be repeated
+    periodSeconds: 15
+    # -- Timeout seconds for readiness probe
+    timeoutSeconds: 15
+    # -- Success threshold for readiness probe
+    successThreshold: 3
+    # -- Failure threshold for readiness probe
+    failureThreshold: 5
+
+  # -- Startup probe parameters for redis container
+  startupProbe:
+    # -- Enable Startup Probe
+    enabled: true
+    # -- Initial delay in seconds for startup probe
+    initialDelaySeconds: 5
+    # -- Period in seconds after which startup probe will be repeated
+    periodSeconds: 10
+    # -- Timeout seconds for startup probe
+    timeoutSeconds: 15
+    # -- Success threshold for startup probe
+    successThreshold: 1
+    # -- Failure threshold for startup probe
+    failureThreshold: 3
+
+  # -- Minimum number of nodes expected to be live.
+  quorum: 2
+
+  # -- Valid sentinel config options in this section will be applied as config options to each sentinel (see below)
+  # @default -- see values.yaml
+  config:
+    ## Additional sentinel conf options can be added below. Only options that
+    ## are expressed in the format simialar to 'sentinel xxx mymaster xxx' will
+    ## be properly templated expect maxclients option.
+    ## For available options see http://download.redis.io/redis-stable/sentinel.conf
+    down-after-milliseconds: 10000
+    ## Failover timeout value in milliseconds
+    failover-timeout: 180000
+    parallel-syncs: 5
+    maxclients: 10000
+
+  ## Custom sentinel.conf files used to override default settings. If this file is
+  ## specified then the sentinel.config above will be ignored.
+  # -- Allows for custom sentinel.conf files to be applied. If this is used then `sentinel.config` is ignored
+  customConfig: ""
+  # customConfig: |-
+    # Define configuration here
+
+  # -- CPU/Memory for sentinel node resource requests/limits
+  resources: {}
+  #  requests:
+  #    memory: 200Mi
+  #    cpu: 100m
+  #  limits:
+  #    memory: 200Mi
+
+  # -- Container Lifecycle Hooks for sentinel container.
+  # Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  lifecycle: {}
+
+  # -- additional volumeMounts for Sentinel container
+  extraVolumeMounts: []
+  #  - name: empty
+  #    mountPath: /empty
+
+# -- Security context to be added to the Redis StatefulSet.
+securityContext:
+  runAsUser: 1000
+  fsGroup: 1000
+  runAsNonRoot: true
+  ## Assuming your kubelet allows it, you can the following instructions to configure
+  ## specific sysctl parameters
+  ##
+  # sysctls:
+  # - name: net.core.somaxconn
+  #   value: '10000'
+
+
+# -- Security context to be added to the Redis containers.
+containerSecurityContext:
+  runAsUser: 1000
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop:
+    - ALL
+
+
+## Node labels, affinity, and tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+# -- Node labels for pod assignment
+nodeSelector: {}
+
+## -- Tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+# -- Whether the Redis server pods should be forced to run on separate nodes.
+## This is accomplished by setting their AntiAffinity with requiredDuringSchedulingIgnoredDuringExecution as opposed to preferred.
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature
+hardAntiAffinity: true
+
+# -- Additional affinities to add to the Redis server pods.
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+additionalAffinities: {}
+##
+## Example:
+##   nodeAffinity:
+##     preferredDuringSchedulingIgnoredDuringExecution:
+##       - weight: 50
+##         preference:
+##           matchExpressions:
+##             - key: spot
+##               operator: NotIn
+##               values:
+##                 - "true"
+##
+
+# -- Override all other affinity settings for the Redis server pods with a string.
+affinity: |
+##
+## Example:
+## affinity: |
+##   podAntiAffinity:
+##     requiredDuringSchedulingIgnoredDuringExecution:
+##       - labelSelector:
+##           matchLabels:
+##             app: {{ template "valkey-ha.name" . }}
+##             release: {{ .Release.Name }}
+##         topologyKey: kubernetes.io/hostname
+##     preferredDuringSchedulingIgnoredDuringExecution:
+##       - weight: 100
+##         podAffinityTerm:
+##           labelSelector:
+##             matchLabels:
+##               app:  {{ template "valkey-ha.name" . }}
+##               release: {{ .Release.Name }}
+##           topologyKey: failure-domain.beta.kubernetes.io/zone
+##
+
+## https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints:
+  # -- Enable topology spread constraints
+  enabled: false
+  # -- Max skew of pods tolerated
+  maxSkew: ""
+  # -- Topology key for spread constraints
+  topologyKey: ""
+  # -- Enforcement policy, hard or soft
+  whenUnsatisfiable: ""
+
+# Prometheus exporter specific configuration options
+exporter:
+  # -- If `true`, the prometheus exporter sidecar is enabled
+  enabled: false
+  # -- Exporter image
+  image: quay.io/oliver006/redis_exporter
+  # -- Exporter image tag
+  tag: v1.80.2
+  # -- Exporter image pullPolicy
+  pullPolicy: IfNotPresent
+
+  # -- Exporter port
+  port: &exporter_port 9121
+  # -- Exporter port name
+  portName: exporter-port
+  # -- Exporter scrape path
+  scrapePath: &exporter_scrapePath /metrics
+
+  # -- Address/Host for Redis instance.
+  # Exists to circumvent issues with IPv6 dns resolution that occurs on certain environments
+  address: localhost
+
+  ## Set this to true if you want to connect to redis tls port
+  # sslEnabled: true
+
+  # -- cpu/memory resource limits/requests
+  resources: {}
+
+  # -- Additional args for redis exporter
+  extraArgs: {}
+
+  # --  A custom custom Lua script that will be mounted to exporter for collection of custom metrics.
+  # Creates a ConfigMap and sets env var `REDIS_EXPORTER_SCRIPT`.
+  script: ""
+  # Used to mount a LUA-Script via config map and use it for metrics-collection
+  # script: |
+  #   -- Example script copied from: https://github.com/oliver006/redis_exporter/blob/master/contrib/sample_collect_script.lua
+  #   -- Example collect script for -script option
+  #   -- This returns a Lua table with alternating keys and values.
+  #   -- Both keys and values must be strings, similar to a HGETALL result.
+  #   -- More info about Redis Lua scripting: https://redis.io/commands/eval
+  #
+  #   local result = {}
+  #
+  #   -- Add all keys and values from some hash in db 5
+  #   redis.call("SELECT", 5)
+  #   local r = redis.call("HGETALL", "some-hash-with-stats")
+  #   if r ~= nil then
+  #   for _,v in ipairs(r) do
+  #   table.insert(result, v) -- alternating keys and values
+  #   end
+  #   end
+  #
+  #   -- Set foo to 42
+  #   table.insert(result, "foo")
+  #   table.insert(result, "42") -- note the string, use tostring() if needed
+  #
+  #   return result
+
+  serviceMonitor:
+    # -- When set true then use a ServiceMonitor to configure scraping
+    enabled: false
+    # -- Set the namespace the ServiceMonitor should be deployed
+    # @default -- `.Release.Namespace`
+    namespace: ""
+    # -- Set how frequently Prometheus should scrape (default is 30s)
+    interval: ""
+    # -- Set path to redis-exporter telemtery-path (default is /metrics)
+    telemetryPath: ""
+    # -- Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+    labels: {}
+    # -- Set timeout for scrape (default is 10s)
+    timeout: ""
+    # -- Set additional properties for the ServiceMonitor endpoints such as relabeling, scrapeTimeout, tlsConfig, and more.
+    endpointAdditionalProperties: {}
+    # -- Disable API Check on ServiceMonitor
+    disableAPICheck: false
+
+    # RelabelConfigs to apply to samples before scraping.
+    relabelings: []
+    # - sourceLabels: [__meta_kubernetes_pod_node_name]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: nodename
+    #   replacement: $1
+    #   action: replace
+
+    # MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
+    metricRelabelings: []
+    # - action: keep
+    #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
+    #   sourceLabels: [__name__]
+
+
+  # prometheus exporter SCANS redis db which can take some time
+  # allow different probe settings to not let container crashloop
+  livenessProbe:
+    httpGet:
+      # -- Exporter liveness probe httpGet path
+      path: *exporter_scrapePath
+      # -- Exporter liveness probe httpGet port
+      port: *exporter_port
+    # -- Initial delay in seconds for liveness probe of exporter
+    initialDelaySeconds: 15
+    # -- Timeout seconds for liveness probe of exporter
+    timeoutSeconds: 3
+    # -- Period in seconds after which liveness probe will be repeated
+    periodSeconds: 15
+
+  readinessProbe:
+    httpGet:
+      # -- Exporter readiness probe httpGet path
+      path: *exporter_scrapePath
+      # -- Exporter readiness probe httpGet port
+      port: *exporter_port
+    # -- Initial delay in seconds for readiness probe of exporter
+    initialDelaySeconds: 15
+    # -- Timeout seconds for readiness probe of exporter
+    timeoutSeconds: 3
+    # -- Period in seconds after which readiness probe will be repeated
+    periodSeconds: 15
+    # -- Success threshold for readiness probe of exporter
+    successThreshold: 2
+
+# -- Pod Disruption Budget rules
+podDisruptionBudget: {}
+  # Use only one of the two
+  # maxUnavailable: 1
+  # minAvailable: 1
+
+# -- Configures redis with AUTH (requirepass & masterauth conf params)
+auth: false
+
+# -- (string) A password that configures a `requirepass` and `masterauth` in the conf parameters (Requires `auth: enabled`)
+redisPassword: ~
+
+# -- Annotations for auth secret
+authSecretAnnotations: {}
+
+## Use existing secret containing key `authKey` (ignores redisPassword)
+## Can also store AWS S3 or SSH secrets in this secret
+## Supports templates like "{{ .Release.Name }}-creds"
+# -- An existing secret containing a key defined by `authKey` that configures `requirepass` and `masterauth` in the conf
+# parameters (Requires `auth: enabled`, cannot be used in conjunction with `.Values.redisPassword`)
+existingSecret: ~
+
+# -- Defines the key holding the redis password in existing secret.
+authKey: auth
+
+persistentVolume:
+  # -- Enable persistent volume
+  enabled: true
+  ## valkey-ha data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  # -- valkey-ha data Persistent Volume Storage Class
+  storageClass: ~
+  # -- Persistent volume access modes
+  accessModes:
+    - ReadWriteOnce
+  # -- Persistent volume size
+  size: 10Gi
+  # -- Annotations for the volume
+  annotations: {}
+  # -- Labels for the volume
+  labels: {}
+init:
+  # -- Extra init resources
+  resources: {}
+
+# To use a hostPath for data, set persistentVolume.enabled to false
+# and define hostPath.path.
+# Warning: this might overwrite existing folders on the host system!
+hostPath:
+  # -- Use this path on the host for data storage.
+  # path is evaluated as template so placeholders are replaced
+  path: ""
+  # path: "/data/{{ .Release.Name }}"
+
+  # -- if chown is true, an init-container with root permissions is launched to
+  # change the owner of the hostPath folder to the user defined in the
+  # security context
+  chown: true
+
+# -- Configuration of `emptyDir`, used only if persistentVolume is disabled and no hostPath specified
+emptyDir: {}
+
+tls:
+  ## Fill the name of secret if you want to use your own TLS certificates.
+  ## The secret should contains keys named by "tls.certFile" - the certificate, "tls.keyFile" - the private key, "tls.caCertFile" - the certificate of CA and "tls.dhParamsFile" - the dh parameter file
+  ## Supports templates like "{{ .Release.Name }}-tls"
+  ## This secret will be generated using files from certs folder if the secretName is not set and redis.tlsPort is set
+  # secretName: tls-secret
+
+  # -- Name of certificate file
+  certFile: redis.crt
+  # -- Name of key file
+  keyFile: redis.key
+  # -- (string) Name of Diffie-Hellman (DH) key exchange parameters file (Example: redis.dh)
+  dhParamsFile: ~
+  # -- Name of CA certificate file
+  caCertFile: ca.crt
+
+# restore init container is executed if restore.[s3|ssh].source is not false
+# restore init container creates /data/dump.rdb_ from original if exists
+# restore init container overrides /data/dump.rdb
+# secrets are stored into environment of init container - stored encoded on k8s
+# REQUIRED for s3 restore: AWS 'access_key' and 'secret_key' or stored in existingSecret
+# EXAMPLE source for s3 restore: 's3://bucket/dump.rdb'
+# REQUIRED for ssh restore: 'key' should be in one line including CR i.e. '-----BEGIN RSA PRIVATE KEY-----\n...\n...\n...\n-----END RSA PRIVATE KEY-----'
+# EXAMPLE source for ssh restore: 'user@server:/path/dump.rdb'
+# REQUIRED for redis restore: 'source' should be in form of redis connection uri: 'redis://[username:password@]host:port[/db]'
+# EXAMPLE source for redis restore: 'redis://username:password@localhost:6379'
+restore:
+  # -- Timeout for the restore
+  timeout: 600
+  # -- Set existingSecret to true to use secret specified in existingSecret above
+  existingSecret: false
+  s3:
+    # -- Restore init container - AWS S3 location of dump - i.e. s3://bucket/dump.rdb or false
+    source: ""
+    # If using existingSecret, that secret must contain:
+    # AWS_SECRET_ACCESS_KEY: <YOUR_ACCESS_KEY:>
+    # AWS_ACCESS_KEY_ID: <YOUR_KEY_ID>
+    # If not set the key and ID as strings below:
+    # -- Restore init container - AWS AWS_ACCESS_KEY_ID to access restore.s3.source
+    access_key: ""
+    # -- Restore init container - AWS AWS_SECRET_ACCESS_KEY to access restore.s3.source
+    secret_key: ""
+    # -- Restore init container - AWS AWS_REGION to access restore.s3.source
+    region: ""
+  ssh:
+    # -- Restore init container - SSH scp location of dump - i.e. user@server:/path/dump.rdb or false
+    source: ""
+    # -- Restore init container - SSH private key to scp restore.ssh.source to init container.
+    # Key should be in one line separated with \n.
+    # i.e. `-----BEGIN RSA PRIVATE KEY-----\n...\n...\n-----END RSA PRIVATE KEY-----`
+    key: ""
+  redis:
+    source: ""
+
+## Custom PrometheusRule to be defined
+## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
+## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
+prometheusRule:
+  # -- If true, creates a Prometheus Operator PrometheusRule.
+  enabled: false
+  # -- Additional labels to be set in metadata.
+  additionalLabels: {}
+  # -- Namespace which Prometheus is running in.
+  namespace:
+  # -- How often rules in the group are evaluated (falls back to `global.evaluation_interval` if not set).
+  interval: 10s
+  # -- Rules spec template (see https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule).
+  rules: []
+    # Example:
+    # - alert: RedisPodDown
+    #   expr: |
+    #     redis_up{job="{{ include "valkey-ha.fullname" . }}"} == 0
+    #   for: 5m
+    #   labels:
+    #     severity: critical
+    #   annotations:
+    #     description: Redis pod {{ "{{ $labels.pod }}" }} is down
+    #     summary: Redis pod {{ "{{ $labels.pod }}" }} is down
+
+# -- Extra init containers to include in StatefulSet
+extraInitContainers: []
+#  - name: extraInit
+#    image: alpine
+
+# -- Extra containers to include in StatefulSet
+extraContainers: []
+#  - name: extra
+#    image: alpine
+
+# -- Extra volumes to include in StatefulSet
+extraVolumes: []
+#  - name: empty
+#    emptyDir: {}
+
+# -- Labels added here are applied to all created resources
+extraLabels: {}
+
+networkPolicy:
+  # -- whether NetworkPolicy for Redis StatefulSets should be created.
+  # when enabled, inter-Redis connectivity is created
+  enabled: false
+  # -- Annotations for NetworkPolicy
+  annotations: {}
+  # -- Labels for NetworkPolicy
+  labels: {}
+  # -- User defined ingress rules that Redis should permit into.
+  # Uses the format defined in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+  ingressRules: []
+    # - selectors:
+    #   - namespaceSelector:
+    #       matchLabels:
+    #         name: my-valkey-client-namespace
+    #     podSelector:
+    #       matchLabels:
+    #         application: valkey-client
+    ## if ports is not defined then it defaults to the ports defined for enabled services (redis, sentinel)
+    #   ports:
+    #     - port: 6379
+    #       protocol: TCP
+    #     - port: 26379
+    #       protocol: TCP
+
+  # -- user can define egress rules too, uses the same structure as ingressRules
+  egressRules:
+    - selectors:
+      # -- Allow all destinations for DNS traffic
+      - namespaceSelector: {}
+      - ipBlock:
+          # Cloud Provider often uses the local link local range to host managed DNS resolvers.
+          # We need to allow this range to ensure that the Redis pods can resolve DNS.
+          # Example architecture for GCP Cloud DNS: https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-dns#architecture
+          cidr: 169.254.0.0/16
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+
+splitBrainDetection:
+  # -- Interval between redis sentinel and server split brain checks (in seconds)
+  interval: 60
+  retryInterval: 10
+  # -- splitBrainDetection resources
+  resources: {}
+  # liveness probe parameters for split brain container
+  livenessProbe:
+    # -- Initial delay in seconds for liveness probe
+    initialDelaySeconds: 30
+    # -- Period in seconds after which liveness probe will be repeated
+    periodSeconds: 15
+    # -- Timeout seconds for liveness probe
+    timeoutSeconds: 15
+    # -- Success threshold for liveness probe
+    successThreshold: 1
+    # -- Failure threshold for liveness probe
+    failureThreshold: 5
+    exec:
+      command:
+        - cat
+        - /readonly-config/redis.conf
+
+  # readiness probe parameters for split brain container
+  readinessProbe:
+    # -- Initial delay in seconds for readiness probe
+    initialDelaySeconds: 30
+    # -- Period in seconds after which readiness probe will be repeated
+    periodSeconds: 15
+    # -- Timeout seconds for readiness probe
+    timeoutSeconds: 15
+    # -- Success threshold for readiness probe
+    successThreshold: 1
+    # -- Failure threshold for readiness probe
+    failureThreshold: 5
+    exec:
+      command:
+        - sh
+        - -c
+        - test -d /proc/1

--- a/charts/valkey-ha/values.yaml
+++ b/charts/valkey-ha/values.yaml
@@ -10,6 +10,16 @@ global:
 ## -- Image information for Valkey HA
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
+## To run with the native Valkey modules (JSON, search, bloom, LDAP, etc.) swap the
+## repository for `valkey/valkey-bundle` and load the modules you need via
+## `redis.config.loadmodule` (a list), e.g.:
+##   image:
+##     repository: valkey/valkey-bundle
+##     tag: 8.1.8
+##   redis:
+##     config:
+##       loadmodule:
+##         - /usr/lib/valkey/libjson.so
 image:
   # -- Valkey image repository
   repository: valkey/valkey
@@ -457,25 +467,38 @@ redis:
     - FLUSHDB
     - FLUSHALL
 
-  # -- Any valid redis config options in this section will be applied to each server, For multi-value configs use list instead of string (for example loadmodule) (see below)
+  # -- Any valid valkey/redis config options in this section will be applied to each server, For multi-value configs use list instead of string (for example loadmodule) (see below)
   # @default -- see values.yaml
   config:
-    ## -- Additional redis conf options can be added below
-    ## -- For all available options see http://download.redis.io/redis-stable/redis.conf
+    ## -- Additional valkey conf options can be added below
+    ## -- For all available options see https://github.com/valkey-io/valkey/blob/8.1/valkey.conf
     min-replicas-to-write: 1
     # -- Value in seconds
     min-replicas-max-lag: 5
-    # -- Max memory to use for each redis instance. Default is unlimited.
+    # -- Max memory to use for each valkey instance. Default is unlimited.
     maxmemory: "0"
-    # -- Max memory policy to use for each redis instance. Default is volatile-lru.
+    # -- Max memory policy to use for each valkey instance. Default is volatile-lru.
     maxmemory-policy: "volatile-lru"
     # -- Determines if scheduled RDB backups are created. Default is false.
-    # -- Please note that local (on-disk) RDBs will still be created when re-syncing with a new slave. The only way to prevent this is to enable diskless replication.
+    # -- Please note that local (on-disk) RDBs will still be created when re-syncing with a new replica. The only way to prevent this is to enable diskless replication.
     save: "900 1"
-    # -- When enabled, directly sends the RDB over the wire to slaves, without using the disk as intermediate storage. Default is false.
+    # -- When enabled, directly sends the RDB over the wire to replicas, without using the disk as intermediate storage. Default is false.
     repl-diskless-sync: "yes"
     rdbcompression: "yes"
     rdbchecksum: "yes"
+    ## Valkey-native tuning (https://valkey.io/blog/valkey-8-0-0-rc1/)
+    # -- (string) Valkey 8.0+ dual-channel replication. Streams the RDB and the
+    # replication backlog on separate channels to speed up full syncs. Set to "yes" to enable.
+    dual-channel-replication-enabled: "no"
+    # -- (int) Number of I/O threads. Valkey 8.0 reworked I/O threading for much
+    # higher throughput on multi-core nodes. Default is 1 (disabled); raise to roughly
+    # the number of cores allocated to the pod to benefit from it.
+    io-threads: 1
+    ## -- (string) Valkey 8.0+ availability zone hint reported by INFO and used by
+    ## AZ-aware clients (e.g. valkey-glide) for locality-aware reads. NOTE: a single
+    ## value applies to every replica, so only set it here when all pods are pinned to
+    ## one zone; otherwise inject a per-pod value via redis.customConfig / extraVolumes.
+    # availability-zone: "us-east-1a"
 
   # -- (string) Allows for custom redis.conf files to be applied. If this is used then `redis.config` is ignored
   customConfig: ~


### PR DESCRIPTION
Adds a new valkey-ha chart, copied from redis-ha, that deploys Valkey
(the open-source, RESP-compatible fork of Redis) in a master/replica
StatefulSet with Sentinel sidecars and optional HAProxy.

Drop-in compatible: the values.yaml interface (redis.* / sentinel.* keys,
auth, TLS, exporter, networkPolicy, etc.) is preserved so existing
redis-ha values can be reused.

Valkey-specific changes:
- Default image -> valkey/valkey:8.1.8-alpine
- Server/sentinel commands -> valkey-server / valkey-sentinel
- All embedded scripts and probes use valkey-cli
- Helm helper templates namespaced as valkey-ha.*
- Chart.yaml metadata (home, sources, keywords, icon, appVersion) updated
- README/NOTES reworded for Valkey