### PR TITLE
feat(redis-ha): add EndpointSlices RBAC support

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.38.0
+version: 4.39.0
 appVersion: 8.8.0
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png

--- a/charts/redis-ha/templates/redis-ha-role.yaml
+++ b/charts/redis-ha/templates/redis-ha-role.yaml
@@ -16,4 +16,11 @@ rules:
     - endpoints
   verbs:
     - get
+# EndpointSlices supersede the Endpoints API, which is deprecated as of Kubernetes v1.33.
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - get
 {{- end }}

--- a/charts/redis-ha/templates/redis-haproxy-role.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-role.yaml
@@ -18,5 +18,12 @@ rules:
     - endpoints
   verbs:
     - get
+# EndpointSlices supersede the Endpoints API, which is deprecated as of Kubernetes v1.33.
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - get
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

Closes #394.

Kubernetes v1.33 deprecates the `Endpoints` API in favor of `EndpointSlices` (`discovery.k8s.io`). The `redis-ha` and `redis-ha-haproxy` `Role`s currently only grant `get` on the legacy `endpoints` resource. This PR adds an equivalent `get` permission on `endpointslices` so the chart continues to work on newer clusters.

The existing `endpoints` permission is retained for backward compatibility — the Endpoints API is deprecated but still served on supported clusters, so this is a non-breaking, additive change.

## Changes

- `templates/redis-ha-role.yaml` — add `discovery.k8s.io/endpointslices` rule
- `templates/redis-haproxy-role.yaml` — add `discovery.k8s.io/endpointslices` rule
- `Chart.yaml` — bump version `4.38.0` → `4.39.0`

## Testing

`helm template` renders both Roles with the new `endpointslices` rule alongside the existing `endpoints` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)