### PR TITLE
fix(redis-ha): recover no-master cycle when sentinel names a replica as master

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.39.0
+version: 4.39.1
 appVersion: 8.8.0
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png

--- a/charts/redis-ha/templates/_configs.tpl
+++ b/charts/redis-ha/templates/_configs.tpl
@@ -493,6 +493,16 @@
     set -e
     }
 
+    promote_self() {
+    set +e
+        if [ "$REDIS_PORT" -eq 0 ]; then
+            redis-cli {{ if .Values.auth }} -a "${AUTH}" --no-auth-warning{{ end }} -p "${REDIS_TLS_PORT}" --tls --cacert /tls-certs/{{ .Values.tls.caCertFile }} {{ if ne (default "yes" .Values.sentinel.authClients) "no"}} --cert /tls-certs/{{ .Values.tls.certFile }} --key /tls-certs/{{ .Values.tls.keyFile }}{{ end }} replicaof no one
+        else
+            redis-cli {{ if .Values.auth }} -a "${AUTH}" --no-auth-warning{{ end }} -p "${REDIS_PORT}" replicaof no one
+        fi
+    set -e
+    }
+
     identify_announce_ip
 
     while [ -z "${ANNOUNCE_IP}" ]; do
@@ -519,10 +529,21 @@
                 sleep {{ .Values.splitBrainDetection.retryInterval }}
                 identify_master
                 redis_role
-                echo "Redis role is $ROLE, expected role is master. No need to reinitialize."
                 if [ "$ROLE" != "master" ]; then
-                    echo "Redis role is $ROLE, expected role is master, reinitializing"
-                    reinit
+                    # Sentinel still names this pod as the master, but Redis here is
+                    # running as a replica. reinit re-runs init.sh + shutdown, which
+                    # for any pod that is not StatefulSet ordinal 0 just re-derives
+                    # `slaveof`, so the pod restarts straight back into a replica and
+                    # Sentinel keeps naming it -> an unrecoverable all-replicas /
+                    # no-master cycle plus a shutdown/CrashLoop loop (#383). Sentinel
+                    # has already elected THIS pod, so make reality match by promoting
+                    # it; only one pod can match get-master-addr-by-name, so this
+                    # cannot create two masters, and the other replicas already target
+                    # this address so their links recover once it is a real master.
+                    echo "Redis role is $ROLE but Sentinel names this pod as master; promoting (replicaof no one)"
+                    promote_self
+                else
+                    echo "Redis role is $ROLE, expected role is master. No need to reinitialize."
                 fi
             fi
         elif [ "${MASTER}" ]; then


### PR DESCRIPTION
## Problem

After disorderly pod restarts (e.g. several redis pods restarting near-simultaneously), the Sentinel quorum can settle on a master address that points at a node whose role is actually `slave`. Every node ends up a replica of another (an **all-replicas / no-master cycle**), so HAProxy `bk_redis_master` has **0 backends** and writes fail until a human intervenes with `sentinel reset`.

[#404](https://github.com/DandyDeveloper/charts/pull/404) (closing #397/#398) added a `sentinel reset` self-heal, but it only fires when `get-master-addr-by-name` returns an **empty** master. The non-empty variant — Sentinel returns a real address that answers `role:slave` — is not covered.

## Root cause

In `fix-split-brain.sh`, when `MASTER == ANNOUNCE_IP` (Sentinel names *this* pod as master) but the local role is `slave`, the script calls `reinit`. `reinit` re-runs `init.sh` (which re-derives `slaveof` for any pod that is **not** StatefulSet ordinal 0) and `shutdown`s the pod. So the pod restarts straight back into a replica while Sentinel keeps naming it → an endless reinit/shutdown **CrashLoop** (the "unnecessary master shutdown" reported in #383) that never elects a master, and the cycle never breaks.

## Fix

When Sentinel names this pod as master but Redis here is a replica, **promote it** with `replicaof no one` instead of reinit-looping it:

- Sentinel has already elected this pod, so promoting it makes reality match Sentinel's view.
- Only one pod can match `get-master-addr-by-name`, so this **cannot create two masters**.
- The other replicas already target this address, so their replication links recover once it is a real master.
- It stops the reinit/shutdown CrashLoop.

This generalizes the self-healing introduced in #404 to the pingable-slave variant. The `else` branch keeps the original "no need to reinitialize" log for the healthy case.

## Validation

- `helm lint` passes; `helm template` confirms `promote_self` / `replicaof no one` render into the split-brain `ConfigMap` and the rest of the chart is unchanged.
- Diff is 2 files (Chart.yaml version bump 4.39.0 → 4.39.1, and the split-brain script).

Refs #398, #397, #383.