### PR TITLE
[stable/redis-ha] don't create haproxy PDB if haproxy disabled

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: redis-ha
 home: https://redis.io/
 keywords:
-- redis
-- keyvalue
-- database
-version: 4.39.0
+  - redis
+  - keyvalue
+  - database
+version: 4.39.1
 appVersion: 8.8.0
 description: This Helm chart provides a highly available Redis implementation with a master/slave configuration and uses Sentinel sidecars for failover management
 icon: https://img.icons8.com/external-tal-revivo-shadow-tal-revivo/24/external-redis-an-in-memory-data-structure-project-implementing-a-distributed-logo-shadow-tal-revivo.png
 maintainers:
-- email: aaron.layfield@gmail.com
-  name: dandydeveloper
+  - email: aaron.layfield@gmail.com
+    name: dandydeveloper
 sources:
-- https://redis.io/download
-- https://github.com/DandyDeveloper/charts/blob/master/charts/redis-ha
-- https://github.com/oliver006/redis_exporter
+  - https://redis.io/download
+  - https://github.com/DandyDeveloper/charts/blob/master/charts/redis-ha
+  - https://github.com/oliver006/redis_exporter

--- a/charts/redis-ha/templates/redis-haproxy-pdb.yaml
+++ b/charts/redis-ha/templates/redis-haproxy-pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.haproxy.podDisruptionBudget -}}
+{{- if and .Values.haproxy.enabled .Values.haproxy.podDisruptionBudget -}}
 apiVersion: {{ template "redis-ha.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:
If there are haproxy PDB values present for some reason but haproxy is not enabled it still creates haproxy PDB

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
